### PR TITLE
Fix login to use signIn

### DIFF
--- a/src/app/auth/login/login.component.ts
+++ b/src/app/auth/login/login.component.ts
@@ -25,12 +25,12 @@ export class LoginComponent {
     if (this.loginForm.invalid) return;
 
     const { email, password } = this.loginForm.value;
-    const { data, error } = await this.authService.signUp(email, password);
+    const { data, error } = await this.authService.signIn(email, password);
 
     if (error) {
-      console.error('Registration failed:', error.message);
+      console.error('Login failed:', error.message);
     } else {
-      console.log('User logined:', data);
+      console.log('User logged in:', data);
       this.router.navigate(['/']); // Redirect to home after successful registration
     }
   }


### PR DESCRIPTION
## Summary
- use the `signIn` method in login component

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684081d591208322950828a06f4e946e