### PR TITLE
fix: update active competition stream

### DIFF
--- a/src/services/competitions.service.ts
+++ b/src/services/competitions.service.ts
@@ -36,10 +36,10 @@ export class CompetitionService {
     );
   }
 
-  userState$ = this.user?.getState().pipe(shareReplay(1));
+  userState$ = this.user?.userState$() ?? of(null);
 
   activeCompetition$ = combineLatest({
-    state: this.userState$ ?? of(null),
+    state: this.userState$,
     competitions: this.list$
   }).pipe(
     map(({ state, competitions }) =>


### PR DESCRIPTION
## Summary
- use reactive user state to compute active competition

## Testing
- `npm test -- --watch=false` *(fails: Chrome binary not available)*

------
https://chatgpt.com/codex/tasks/task_e_68b379821de08322b6ecbc7991c4b258