### PR TITLE
chore: add missing translations

### DIFF
--- a/public/lang.json
+++ b/public/lang.json
@@ -462,5 +462,101 @@
     "create_cta": {
         "it": "Crea una nuova competizione",
         "en": "Create a new competition"
+    },
+    "pt": {
+        "it": "PT",
+        "en": "PT"
+    },
+    "wr_percent": {
+        "it": "WR%",
+        "en": "WR%"
+    },
+    "login": {
+        "it": "Login",
+        "en": "Login"
+    },
+    "enter_email": {
+        "it": "Inserisci la tua email",
+        "en": "Enter your email"
+    },
+    "enter_password": {
+        "it": "Inserisci la tua password",
+        "en": "Enter your password"
+    },
+    "confirm_password": {
+        "it": "Conferma la tua password",
+        "en": "Confirm your password"
+    },
+    "login_google": {
+        "it": "Entra con Google",
+        "en": "Log in with Google"
+    },
+    "logout": {
+        "it": "Esci",
+        "en": "Log Out"
+    },
+    "menu_works": {
+        "it": "menu funziona!",
+        "en": "menu works!"
+    },
+    "add_user": {
+        "it": "Aggiungi utente",
+        "en": "Add user"
+    },
+    "first_name": {
+        "it": "Nome",
+        "en": "First name"
+    },
+    "insert_name": {
+        "it": "Inserisci nome",
+        "en": "Enter name"
+    },
+    "last_name": {
+        "it": "Cognome",
+        "en": "Last name"
+    },
+    "insert_last_name": {
+        "it": "Inserisci cognome",
+        "en": "Enter last name"
+    },
+    "insert_nickname": {
+        "it": "Inserisci nickname",
+        "en": "Enter nickname"
+    },
+    "image": {
+        "it": "Immagine",
+        "en": "Image"
+    },
+    "added_users": {
+        "it": "Utenti aggiunti",
+        "en": "Added users"
+    },
+    "sets": {
+        "it": "SET",
+        "en": "SETS"
+    },
+    "set": {
+        "it": "set",
+        "en": "set"
+    },
+    "advantage": {
+        "it": "Ai vantaggi",
+        "en": "Advantage"
+    },
+    "no_competition": {
+        "it": "Nessuna competizione attiva",
+        "en": "No active competition"
+    },
+    "loader_alt": {
+        "it": "Caricamento",
+        "en": "Loading"
+    },
+    "small_loader_alt": {
+        "it": "Caricamento",
+        "en": "Loading"
+    },
+    "avatar_alt": {
+        "it": "avatar",
+        "en": "avatar"
     }
 }

--- a/src/app/auth/login/login.component.html
+++ b/src/app/auth/login/login.component.html
@@ -1,23 +1,22 @@
 <app-registration-navbar [isLogin]="true"></app-registration-navbar>
 <div class="login-wrapper">
     <div class="login-container">
-        <h2>Login</h2>
+        <h2>{{ 'login' | translate }}</h2>
         <form class="form-dark" [formGroup]="loginForm" (ngSubmit)="onLogin()">
             <div class="input-container">
                 <i class="fa fa-envelope-o" aria-hidden="true"></i>
-                <input id="email" type="email" formControlName="email" placeholder="Enter your email" required>
+                  <input id="email" type="email" formControlName="email" [placeholder]="'enter_email' | translate" required>
             </div>
 
             <div class="input-container">
                 <i class="fa fa-key" aria-hidden="true"></i>
-                <input id="password" type="password" formControlName="password" placeholder="Enter your password"
-                    required>
+                  <input id="password" type="password" formControlName="password" [placeholder]="'enter_password' | translate"
+                      required>
             </div>
 
             <div class="mt-4 text-center">
-                <button (click)="onLogin()" type="button" [disabled]="loginForm.invalid">Login</button>
-                <button id="googleBtn" type="button" (click)="googleSignIn($event)" class="mt-4"><img src="/google.png">Entra con
-                    Google</button>
+                  <button (click)="onLogin()" type="button" [disabled]="loginForm.invalid">{{ 'login' | translate }}</button>
+                  <button id="googleBtn" type="button" (click)="googleSignIn($event)" class="mt-4"><img src="/google.png">{{ 'login_google' | translate }}</button>
             </div>
             <p class="mt-3 text-center">
                 <a routerLink="/register" class="register text-decoration-underline" routerLink="/register">{{'register'

--- a/src/app/auth/register/register.component.html
+++ b/src/app/auth/register/register.component.html
@@ -6,17 +6,17 @@
     <form class="form-dark" [formGroup]="registerForm" (ngSubmit)="onRegister()">
         <div class="input-container">
             <i class="fa fa-envelope-o" aria-hidden="true"></i>
-            <input id="email" type="email" formControlName="email" placeholder="Enter your email" required>
+              <input id="email" type="email" formControlName="email" [placeholder]="'enter_email' | translate" required>
         </div>
 
         <div class="input-container">
             <i class="fa fa-key" aria-hidden="true"></i>
-            <input id="password" type="password" formControlName="password" placeholder="Enter your password" required>
+              <input id="password" type="password" formControlName="password" [placeholder]="'enter_password' | translate" required>
         </div>
         <div class="input-container">
             <i class="fa fa-unlock-alt" aria-hidden="true"></i>
-            <input id="passwordConfirm" type="password" formControlName="confirmPassword"
-                placeholder="Confirm your password" required>
+              <input id="passwordConfirm" type="password" formControlName="confirmPassword"
+                  [placeholder]="'confirm_password' | translate" required>
         </div>
 
 

--- a/src/app/common/menu/menu.component.html
+++ b/src/app/common/menu/menu.component.html
@@ -1,1 +1,1 @@
-<p>menu works!</p>
+<p>{{ 'menu_works' | translate }}</p>

--- a/src/app/common/navbar/navbar.component.html
+++ b/src/app/common/navbar/navbar.component.html
@@ -27,7 +27,7 @@
 
             <a (click)="logout()" *ngIf="!isMobile && (auth.isLoggedIn$ | async)" class="button-navbar">
                 <i class="fa fa-sign-out" aria-hidden="true"></i>
-                <span> Log Out</span>
+                  <span>{{ 'logout' | translate }}</span>
             </a>
 
             <ng-container *ngIf="auth.isLoggedIn$ | async">
@@ -44,7 +44,7 @@
                                 <a routerLink="/competitions"> {{"Competizioni" | translate}} </a>
                             </li>
                             <li class="clickable" style="color: #c76360;">
-                                <a (click)="logout()">Log Out</a>
+                                  <a (click)="logout()">{{ 'logout' | translate }}</a>
                             </li>
                         </ul>
                     </div>

--- a/src/app/common/stats/stats.component.html
+++ b/src/app/common/stats/stats.component.html
@@ -21,11 +21,11 @@
   <div class="vittorie" title="{{ 'vittorieTitle' | translate }}">{{ player.wins }}</div>
   <div class="sconfitte" title="{{ 'sconfitteTitle' | translate }}">{{ player.lost }}</div>
   <div class="partite-rating" title="{{ 'ratingEloTitle' | translate }}">
-    <span class="mini-info">PT</span>
+    <span class="mini-info">{{ 'pt' | translate }}</span>
     {{ (player.rating)?.toFixed(1) }}
   </div>
   <div class="win-rate" title="{{ 'winRateTitle' | translate }}">
-    <span class="mini-info">WR%</span>
+    <span class="mini-info">{{ 'wr_percent' | translate }}</span>
     <div class="rate-label">{{ winRateLabel(player.winRate) }}</div>
     <div class="win-rate-bar"
       [style.width.%]="barWidthPct(player.winRate)"

--- a/src/app/components/add-match-modal/add-match-modal.component.html
+++ b/src/app/components/add-match-modal/add-match-modal.component.html
@@ -1,7 +1,7 @@
 <div class="modal-content">
     <form class="form-dark" [formGroup]="matchForm" (ngSubmit)="addMatch()">
         <div>
-            <label for="date" class="my-placeholder">Data</label>
+            <label for="date" class="my-placeholder">{{ 'date' | translate }}</label>
             <input class="my-placeholder" class="my-placeholder" id="date" type="date" formControlName="date" required>
         </div>
 

--- a/src/app/components/add-players-modal/add-players-modal.component.html
+++ b/src/app/components/add-players-modal/add-players-modal.component.html
@@ -33,31 +33,31 @@
 
                 <!-- Colonna sinistra: form -->
                 <div class="col-md-6">
-                    <h5 class="mb-3">Aggiungi utente</h5>
+                      <h5 class="mb-3">{{ 'add_user' | translate }}</h5>
                     <form>
                         <!-- Nome -->
                         <div class="mb-3">
-                            <label for="nome" class="form-label">Nome</label>
-                            <input type="text" id="nome" class="form-control input-field" placeholder="Inserisci nome">
+                              <label for="nome" class="form-label">{{ 'first_name' | translate }}</label>
+                              <input type="text" id="nome" class="form-control input-field" [placeholder]="'insert_name' | translate">
                         </div>
 
                         <!-- Cognome -->
                         <div class="mb-3">
-                            <label for="cognome" class="form-label">Cognome</label>
-                            <input type="text" id="cognome" class="form-control input-field"
-                                placeholder="Inserisci cognome">
+                              <label for="cognome" class="form-label">{{ 'last_name' | translate }}</label>
+                              <input type="text" id="cognome" class="form-control input-field"
+                                  [placeholder]="'insert_last_name' | translate">
                         </div>
 
                         <!-- Nickname -->
                         <div class="mb-3">
-                            <label for="nickname" class="form-label">Nickname</label>
-                            <input type="text" id="nickname" class="form-control input-field"
-                                placeholder="Inserisci nickname">
+                              <label for="nickname" class="form-label">{{ 'nickname' | translate }}</label>
+                              <input type="text" id="nickname" class="form-control input-field"
+                                  [placeholder]="'insert_nickname' | translate">
                         </div>
 
                         <!-- Upload immagine -->
                         <div class="mb-3">
-                            <label for="immagine" class="form-label">Immagine</label>
+                              <label for="immagine" class="form-label">{{ 'image' | translate }}</label>
                             <input type="file" id="immagine" class="form-control input-field">
                         </div>
 
@@ -69,19 +69,9 @@
 
                 <!-- Colonna destra: utenti aggiunti -->
                 <div class="col-md-6">
-                    <h5 class="mb-3">Utenti aggiunti</h5>
-                    <ul class="list-group">
-                        <li class="list-group-item d-flex align-items-center justify-content-between">
-                            <span><img src="https://via.placeholder.com/32" class="rounded-circle me-2"> Mario
-                                Rossi</span>
-                            <small>nickname123</small>
-                        </li>
-                        <li class="list-group-item d-flex align-items-center justify-content-between">
-                            <span><img src="https://via.placeholder.com/32" class="rounded-circle me-2"> Luca
-                                Bianchi</span>
-                            <small>luca_b</small>
-                        </li>
-                    </ul>
+                      <h5 class="mb-3">{{ 'added_users' | translate }}</h5>
+                      <ul class="list-group">
+                      </ul>
                 </div>
             </div>
         </div>

--- a/src/app/components/competitions/competition-detail/competition-detail.component.html
+++ b/src/app/components/competitions/competition-detail/competition-detail.component.html
@@ -34,7 +34,7 @@
     <div class="players-container mt-5 d-flex justify-content-between align-items-center">
       <div class="competition-players-container">
         <div class="players" *ngFor="let c of competition?.['players']">
-          <img [src]="'a'" alt="avatar" />
+            <img [src]="'a'" alt="{{ 'avatar_alt' | translate }}" />
         </div>
         <div class="p-2" *ngIf="isEmpty(competition?.['players'])">
           {{ "no_players" | translate }}

--- a/src/app/components/profile/complete-profile/complete-profile.component.html
+++ b/src/app/components/profile/complete-profile/complete-profile.component.html
@@ -3,7 +3,7 @@
         <h2>
             {{"complete_profile" | translate}}
         </h2>
-        <ng-template #noComp>Nessuna competizione attiva</ng-template>
+        <ng-template #noComp>{{ 'no_competition' | translate }}</ng-template>
         <section>
             <p class="instructions" *ngIf="state?.state ===  PROGRESS_STATE.PROFILE_NOT_COMPLETED">
                 {{ "paragraph_complete" | translate}}
@@ -14,7 +14,7 @@
                     <div class="upload-container">
                         <label for="file-upload" class="custom-file-upload">
                             <i class="fa fa-upload" aria-hidden="true"></i>
-                            <img [src]="previewUrl || '/default-player.jpg'" alt="avatar" />
+                              <img [src]="previewUrl || '/default-player.jpg'" alt="{{ 'avatar_alt' | translate }}" />
                             <input id="file-upload" type="file" accept="image/*" (change)="onFileSelected($event)" />
                         </label>
                     </div>

--- a/src/app/components/profile/profile/profile.component.html
+++ b/src/app/components/profile/profile/profile.component.html
@@ -8,14 +8,14 @@
                 [monthlyWinRates]="{ '01': 50, '02': 70, '03': 30 }" [badges]="['gold', 'silver']">
             </app-player-detail>
         </section>
-        <ng-template #noComp>Nessuna competizione attiva</ng-template>
+          <ng-template #noComp>{{ 'no_competition' | translate }}</ng-template>
         <section>
             <form [formGroup]="form" class="form-dark">
                 <div class="d-flex justify-content-center align-items-center mt-5" style="gap: 1em;">
                     <div class="upload-container">
                         <label for="file-upload" class="custom-file-upload">
                             <i class="fa fa-upload" aria-hidden="true"></i>
-                            <img [src]="previewUrl || '/default-player.jpg'" alt="avatar" />
+                              <img [src]="previewUrl || '/default-player.jpg'" alt="{{ 'avatar_alt' | translate }}" />
                             <input id="file-upload" type="file" accept="image/*" (change)="onFileSelected($event)" />
                         </label>
                     </div>

--- a/src/app/components/show-match-modal/show-match-modal.component.html
+++ b/src/app/components/show-match-modal/show-match-modal.component.html
@@ -10,7 +10,7 @@
             <div class="score">{{ match?.player1_score }}</div>
         </div>
         <div class="vs">
-            <img src="/vs.svg" alt="VS">
+            <img src="/vs.svg" alt="{{ 'vs' | translate }}">
         </div>
         <div class="player player-2">
             <div class="p-3">
@@ -21,12 +21,12 @@
         </div>
     </div>
     <div class="other" *ngIf="match?.match_sets?.length > 1">
-        <h5 class="text-center">SETS</h5>
+        <h5 class="text-center">{{ 'sets' | translate }}</h5>
         <div class="sets-points">
             <div class="set" *ngFor="let set of match.match_sets; let i = index">
-                <div class="n-set">{{ i + 1 }}º set</div>
+                <div class="n-set">{{ i + 1 }}º {{ 'set' | translate }}</div>
                 <div><span [ngClass]="{ 'won': set.player1_score > set.player2_score }">{{ set.player1_score }}</span></div>
-                <div class="separator">{{ set.player1_score == 20 || set.player2_score == 20 ? ('Ai vantaggi' | translate) : '-' }}</div>
+                <div class="separator">{{ set.player1_score == 20 || set.player2_score == 20 ? ('advantage' | translate) : '-' }}</div>
                 <div><span [ngClass]="{ 'won': set.player2_score > set.player1_score }">{{ set.player2_score }}</span></div>
             </div>
         </div>

--- a/src/app/utils/components/loader/loader.component.html
+++ b/src/app/utils/components/loader/loader.component.html
@@ -1,7 +1,7 @@
-<div *ngIf="isLoading" class="loader">
-  <div class="loading-text">{{"loading" | translate}}.</div>
-  <img src="/ping-pong.gif" alt="Loader">
-</div>
+  <div *ngIf="isLoading" class="loader">
+    <div class="loading-text">{{"loading" | translate}}.</div>
+    <img src="/ping-pong.gif" alt="{{ 'loader_alt' | translate }}">
+  </div>
 
 <div *ngIf="toastMessage" class="ping-toast" [ngClass]="toastClass">
   <div><i class="fa-solid" [ngClass]="toastIcon"></i></div>
@@ -9,6 +9,6 @@
   <button class="close-toast" (click)="closeToast()"><i class="fa-solid fa-close"></i></button>
 </div>
 
-<div *ngIf="isSmallLoading" class="loader-small">
-  <img src="./loading_small.gif" alt="Small Loader">
-</div>
+  <div *ngIf="isSmallLoading" class="loader-small">
+    <img src="./loading_small.gif" alt="{{ 'small_loader_alt' | translate }}">
+  </div>


### PR DESCRIPTION
## Summary
- replace hardcoded strings with translation keys in login, modals, and loaders
- add missing entries to `lang.json`

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68b449641e0c8322b3de5cda6875f923