### PR TITLE
Ensure local store reflects new matches and players

### DIFF
--- a/src/app/components/add-players-modal/add-players-modal.component.ts
+++ b/src/app/components/add-players-modal/add-players-modal.component.ts
@@ -11,6 +11,7 @@ import { LoaderService } from '../../../services/loader.service';
 import { MSG_TYPE } from '../../utils/enum';
 import { firstValueFrom } from 'rxjs';
 import { ModalComponent } from '../../common/modal/modal.component';
+import { DataService } from '../../../services/data.service';
 
 export interface IPlayerToAdd {
   name: string;
@@ -32,6 +33,7 @@ export class AddPlayersModalComponent extends ModalComponent {
   private loader = inject(LoaderService);
   private userService = inject(UserService);
   private competitionService = inject(CompetitionService);
+  private dataService = inject(DataService);
 
   addPlayerForm: FormGroup = this.fb.group({
     name: [''],
@@ -117,6 +119,8 @@ export class AddPlayersModalComponent extends ModalComponent {
       await firstValueFrom(
         this.http.post(API_PATHS.addPlayers, { players: playersWithUrls, competitionId })
       );
+      // refresh dati locali (players, matches, ecc.)
+      await this.dataService.refresh();
       this.modalService.closeModal();
       this.loader.showToast('Players added successfully!', MSG_TYPE.SUCCESS);
       this.playersToAdd = [];

--- a/src/services/data.service.ts
+++ b/src/services/data.service.ts
@@ -57,11 +57,13 @@ export class DataService {
   private totPlayedSubject = new BehaviorSubject<Record<string, number>>({});
   private pointsSubject = new BehaviorSubject<Record<string, number>>({});
   private matchesSubject = new BehaviorSubject<IMatch[]>([]);
+  private playersSubject = new BehaviorSubject<string[]>([]);
 
   public winsObs = this.winsSubject.asObservable();
   public totPlayedObs = this.totPlayedSubject.asObservable();
   public pointsObs = this.pointsSubject.asObservable();
   public matchesObs = this.matchesSubject.asObservable();
+  public playersObs = this.playersSubject.asObservable();
 
   private _loaded = false;                 // abbiamo già i dati?
   private _lastLoadedAt = 0;               // timestamp dell’ultimo load
@@ -161,6 +163,7 @@ export class DataService {
     this.winsSubject.next(this.wins);
     this.totPlayedSubject.next(this.totPlayed);
     this.pointsSubject.next(this.points);
+    this.playersSubject.next(this.players);
   }
 
   private generateReturnObject(): MatchData {
@@ -201,9 +204,11 @@ export class DataService {
       }
 
       const responseData = await firstValueFrom(
-        this.http.post<any>(url, { ...data, competitionId: userState.active_competition_id })
+        this.http.post<IMatchResponse>(url, { ...data, competitionId: userState.active_competition_id })
       );
 
+      // aggiorna lo store locale con i dati restituiti
+      this.assignData(responseData);
       this.loaderService?.showToast('Salvato con successo!', MSG_TYPE.SUCCESS, 5000);
       console.log('Success:', responseData);
     } catch (error: any) {


### PR DESCRIPTION
## Summary
- Sync local store with backend response when adding a match
- Refresh cached data after adding players and expose players observable

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless --progress=false` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5b7d6c9483229e66c8ef060013ba