### PR TITLE
refactor: use em units instead of px

### DIFF
--- a/public/Logo.svg
+++ b/public/Logo.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0em" y="0em"
 	 viewBox="0 0 1000 1000" style="enable-background:new 0 0 1000 1000;" xml:space="preserve">
 <style type="text/css">
 	.st0{fill:#FFFFFF;}

--- a/public/ping.svg
+++ b/public/ping.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
-<svg height="800px" width="800px" version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+<svg height="50em" width="50em" version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
 	 viewBox="0 0 57.975 57.975" xml:space="preserve">
 <path style="fill:#CBB292;" d="M10.39,23.151c-0.167,2.943,0.41,5.903,1.767,8.819c0.83,1.782,1.141,3.785,0.667,5.693
 	c-0.786,3.165-2.687,5.7-6.161,7.757c-1.371,0.812-2.72,1.664-3.983,2.635l-1.591,1.224c-0.926,0.712-1.014,2.075-0.188,2.901

--- a/public/vs.svg
+++ b/public/vs.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Livello_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+<svg version="1.1" id="Livello_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0em" y="0em"
 	 viewBox="0 0 500 500" style="enable-background:new 0 0 500 500;" xml:space="preserve">
 <style type="text/css">
 	.st0{fill:#FFFFFF;}

--- a/src/app/auth/login/login.component.scss
+++ b/src/app/auth/login/login.component.scss
@@ -5,7 +5,7 @@
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    width: 250px;
+    width: 15.625em;
 
     form {
         position: relative;
@@ -26,7 +26,7 @@
         color: white;
         cursor: pointer;
         padding: 0.5em;
-        width: 250px;
+        width: 15.625em;
         display: block;
         box-sizing: border-box;
         transition: all 0.2s ease-in;
@@ -43,7 +43,7 @@
             position: absolute;
             top: 50%;
             transform: translateY(-50%);
-            left: 10px;
+            left: 0.625em;
         }
     }
 }
@@ -51,8 +51,8 @@
 
 button {
     width: 100%;
-    padding: 10px;
-    font-size: 16px;
+    padding: 0.625em;
+    font-size: 1em;
     border: none;
     border-radius: $border-radius;
     cursor: pointer;
@@ -62,7 +62,7 @@ button {
 
 #googleBtn {
     background-color: white;
-    border: 2px solid black;
+    border: 0.125em solid black;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -71,7 +71,7 @@ button {
     img {
         width: auto;
         height: 1.5em;
-        margin-right: 8px;
+        margin-right: 0.5em;
     }
 }
 a.register {

--- a/src/app/auth/login/registration-navbar/registration-navbar.component.html
+++ b/src/app/auth/login/registration-navbar/registration-navbar.component.html
@@ -1,5 +1,5 @@
 <nav>
-    <a *ngIf="!isLogin" routerLink="/login" style="cursor: pointer; gap: 10px;" class="d-flex justify-content-center align-items-center">
+    <a *ngIf="!isLogin" routerLink="/login" style="cursor: pointer; gap: 0.625em;" class="d-flex justify-content-center align-items-center">
         <i class="fa fa-arrow-left"></i>
         <span> Login </span>
     </a>

--- a/src/app/auth/register/register.component.scss
+++ b/src/app/auth/register/register.component.scss
@@ -5,7 +5,7 @@
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    width: 250px;
+    width: 15.625em;
 
     form {
         position: relative;
@@ -25,7 +25,7 @@
             position: absolute;
             top: 50%;
             transform: translateY(-50%);
-            left: 10px;
+            left: 0.625em;
         }
     }
 
@@ -37,7 +37,7 @@
         color: white;
         cursor: pointer;
         padding: 0.5em;
-        width: 250px;
+        width: 15.625em;
         display: block;
         box-sizing: border-box;
         transition: all 0.2s ease-in;
@@ -52,8 +52,8 @@
 
 button {
     width: 100%;
-    padding: 10px;
-    font-size: 16px;
+    padding: 0.625em;
+    font-size: 1em;
     border: none;
     border-radius: $border-radius;
     cursor: pointer;
@@ -63,7 +63,7 @@ button {
 
 #googleBtn {
     background-color: white;
-    border: 2px solid black;
+    border: 0.125em solid black;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -72,6 +72,6 @@ button {
     img {
         width: auto;
         height: 1.5em;
-        margin-right: 8px;
+        margin-right: 0.5em;
     }
 }

--- a/src/app/common/bottom-navbar/bottom-navbar.component.scss
+++ b/src/app/common/bottom-navbar/bottom-navbar.component.scss
@@ -3,7 +3,7 @@
 .bottom-navbar {
     padding: 0.5em;
     background-color: #142733;
-    height: 75px;
+    height: 4.6875em;
     display: flex;
     justify-content: space-around;
     align-items: center;
@@ -15,8 +15,8 @@
     left: 50%;
     bottom: 1em;
     transform: translateX(-50%);
-    max-width: 600px;
-    filter: drop-shadow(0px 0px 10px black);
+    max-width: 37.5em;
+    filter: drop-shadow(0em 0em 0.625em black);
 
     .bottom-navbar-item {
         display: flex;
@@ -51,7 +51,7 @@
         }
     }
 }
-@media screen and (min-width: 768px) {
+@media screen and (min-width: 48em) {
     .bottom-navbar {
         display: none;
     }

--- a/src/app/common/dropdown/dropdown.component.html
+++ b/src/app/common/dropdown/dropdown.component.html
@@ -6,7 +6,7 @@
     <div *ngIf="isOpen" class="dropdown-dots d-flex flex-column">
         <button *ngFor="let a of actions" (click)="select(a.value)"
             [style]="a.value === 'delete' ? 'color: var(--contrast);' : ''">
-            <div class="d-flex justify-content-left" style="gap: 10px;">
+            <div class="d-flex justify-content-left" style="gap: 0.625em;">
                 <span *ngIf="a.icon" [innerHTML]="a.icon"></span>
                  {{ a.label }}
             </div>

--- a/src/app/common/dropdown/dropdown.component.scss
+++ b/src/app/common/dropdown/dropdown.component.scss
@@ -12,8 +12,8 @@
     }
 
     position: absolute;
-    bottom: -2px;
-    right: 0px;
+    bottom: -0.125em;
+    right: 0em;
 }
 
 .relative {
@@ -31,10 +31,10 @@
     color: white;
     border-radius: 0.5rem;
     padding: 0.25rem;
-    box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2);
+    box-shadow: 0em 0.25em 0.5em rgba(0, 0, 0, 0.2);
     display: flex;
     flex-direction: column;
-    min-width: 120px;
+    min-width: 7.5em;
     z-index: 900;
 }
 

--- a/src/app/common/navbar/navbar.component.scss
+++ b/src/app/common/navbar/navbar.component.scss
@@ -18,7 +18,7 @@
 }
 
 .button-navbar {
-    border-radius: 1px;
+    border-radius: 0.0625em;
     font-size: 0.75em;
 
     i {
@@ -68,11 +68,11 @@
 }
 
 .curtain {
-    border-radius: 10px;
+    border-radius: 0.625em;
     background-color: $dark;
-    filter: drop-shadow(0px 0px 10px black);
+    filter: drop-shadow(0em 0em 0.625em black);
     position: absolute;
-    top: 75px;
+    top: 4.6875em;
     right: 0;
     animation: open 0.2s ease-in-out forwards;
 
@@ -109,14 +109,14 @@
 }
 
 
-@media screen and (min-width: 768px) {
+@media screen and (min-width: 48em) {
     .curtain {
         display: none;
     }
 
 }
 
-@media screen and (max-width: 768px) {
+@media screen and (max-width: 48em) {
     .buttons-container {
         height: 100%;
 

--- a/src/app/common/stats/stats.component.scss
+++ b/src/app/common/stats/stats.component.scss
@@ -1,8 +1,8 @@
 @use '../../../style/variables.scss' as *;
 
 img {
-  width: 50px;
-  height: 50px;
+  width: 3.125em;
+  height: 3.125em;
   border-radius: 50%;
 }
 
@@ -36,7 +36,7 @@ img {
   }
 
   .win-rate-bar {
-    height: 5px;
+    height: 0.3125em;
     transform: skew(-20deg) !important;
     opacity: 0.75;
   }
@@ -79,8 +79,8 @@ img {
     }
 
     img {
-      width: 65px;
-      height: 65px;
+      width: 4.0625em;
+      height: 4.0625em;
       object-fit: cover;
       border-radius: 50%;
     }
@@ -105,8 +105,8 @@ img {
 }
 
 .players .player img {
-  width: 60px;
-  height: 60px;
+  width: 3.75em;
+  height: 3.75em;
   object-fit: cover;
   border-radius: 50%;
 }
@@ -123,20 +123,20 @@ img {
 }
 
 .vs img {
-  width: 40px;
-  height: 40px;
+  width: 2.5em;
+  height: 2.5em;
 }
 
 .win-bar {
   display: grid;
-  grid-template-columns: 50px 1fr 50px;
+  grid-template-columns: 3.125em 1fr 3.125em;
   align-items: center;
   gap: 0.5rem;
 }
 
 .bars {
   position: relative;
-  height: 12px;
+  height: 0.75em;
   display: flex;
   transform: skew(-30deg);
 }
@@ -165,12 +165,12 @@ img {
 .mini-info {
   display: none;
   position: absolute;
-  top: -18px;
-  left: 5px;
-  font-size: 10px;
+  top: -1.125em;
+  left: 0.3125em;
+  font-size: 0.625em;
   color: rgba(202, 202, 57, 0.905);
 }
-@media screen and (max-width: 600px) {
+@media screen and (max-width: 37.5em) {
   .partite-tot {
     display: none;
   }
@@ -185,7 +185,7 @@ img {
   .stats-container,
   .stats-header {
     grid-template-columns:  0.5fr 0.5fr repeat(3, 1fr);
-    gap: 20px;
+    gap: 1.25em;
   }
   .stats-header {
     display: none;

--- a/src/app/common/step-indicator/step-indicator.component.scss
+++ b/src/app/common/step-indicator/step-indicator.component.scss
@@ -1,14 +1,14 @@
 @use '../../../style/variables.scss' as *;
 
 .step-indicator {
-    max-width: 100px;
+    max-width: 6.25em;
     margin: auto;
     margin-top: 1em;
     transition: all 0.5s ease-in-out;
     .circle {
         border-radius: 100%;
         background-color: transparent;
-        border: 2px solid white;
+        border: 0.125em solid white;
         width: 1em;
         height: 1em;
         transition: all 0.5s ease-in-out;
@@ -16,8 +16,8 @@
     }
 
     .line {
-        min-width: 50px;
-        border: 1px solid white;
+        min-width: 3.125em;
+        border: 0.0625em solid white;
         &.completed {
             border-color: $primary-light;
             transition: all 0.5s ease-in-out;

--- a/src/app/components/add-players-modal/add-players-modal.component.html
+++ b/src/app/components/add-players-modal/add-players-modal.component.html
@@ -86,7 +86,7 @@
                 <!-- Colonna destra: utenti aggiunti -->
                 <div class="col-md-6">
                     <h5 class="mb-3">{{ 'added_users' | translate }}</h5>
-                    <ul class="list-group players-added" style="max-height: 375px; overflow-y: auto;">
+                    <ul class="list-group players-added" style="max-height: 23.4375em; overflow-y: auto;">
                         <li *ngFor="let item of playersToAdd; let i = index"
                             class="field list-group-item d-flex align-items-center justify-content-between">
                             <span class="d-flex align-items-center">

--- a/src/app/components/add-players-modal/add-players-modal.component.scss
+++ b/src/app/components/add-players-modal/add-players-modal.component.scss
@@ -11,7 +11,7 @@ p {
 }
 .list-group-item {
     color: white;
-    border: 1px solid $dark;
+    border: 0.0625em solid $dark;
     padding-right: 0;
 }
 .text-muted {

--- a/src/app/components/competitions/add-competition-modal/add-competition-modal.component.html
+++ b/src/app/components/competitions/add-competition-modal/add-competition-modal.component.html
@@ -75,7 +75,7 @@
                     <input type="radio" value="league" formControlName="typeCtrl" />
                     <span class="large-img-select">
                         <span>{{ 'competition_type_league' | translate }}</span>
-                        <img width="50px" height="50px" src="/numbered-list.png" alt="">
+                        <img width="3.125em" height="3.125em" src="/numbered-list.png" alt="">
                     </span>
                 </label>
 

--- a/src/app/components/competitions/add-competition-modal/add-competition-modal.component.scss
+++ b/src/app/components/competitions/add-competition-modal/add-competition-modal.component.scss
@@ -5,13 +5,13 @@
 }
 
 .form-card {
-    max-width: 720px;
-    border: 1px solid rgba(0, 0, 0, .06);
-    border-radius: 16px;
-    box-shadow: 0 8px 30px rgba(0, 0, 0, .06);
+    max-width: 45em;
+    border: 0.0625em solid rgba(0, 0, 0, .06);
+    border-radius: 1em;
+    box-shadow: 0 0.5em 1.875em rgba(0, 0, 0, .06);
     display: flex;
     flex-direction: column;
-    gap: 18px;
+    gap: 1.125em;
     height: 100%;
 }
 
@@ -22,7 +22,7 @@
 }
 
 .steps-wrapper {
-    padding: 24px;
+    padding: 1.5em;
     height: 100%;
     display: flex;
     flex-direction: column;
@@ -30,7 +30,7 @@
 }
 
 h2 {
-    margin: 0 0 6px;
+    margin: 0 0 0.375em;
     font-size: 1.25rem;
 }
 
@@ -40,18 +40,18 @@ h2 {
     font-size: .9rem;
     opacity: .85;
     display: block;
-    margin-bottom: 5px;
+    margin-bottom: 0.3125em;
 }
 
 .input {
-    padding: 12px 14px;
-    border-radius: 12px;
+    padding: 0.75em 0.875em;
+    border-radius: 0.75em;
     transition: border-color .15s, box-shadow .15s;
 }
 
 .input:focus {
     border-color: $primary-light;
-    box-shadow: 0 0 0 4px rgba(63, 81, 181, .12);
+    box-shadow: 0 0 0 0.25em rgba(63, 81, 181, .12);
 }
 
 .error {
@@ -62,17 +62,17 @@ h2 {
     display: grid;
     grid-auto-flow: column;
     grid-auto-columns: 1fr;
-    gap: 10px;
+    gap: 0.625em;
 }
 
 .seg-item {
     position: relative;
     display: block;
-    border-radius: 12px;
+    border-radius: 0.75em;
     user-select: none;
 
     &>span:not(.large-img-select) {
-        min-height: 70px;
+        min-height: 4.375em;
     }
 }
 
@@ -89,8 +89,8 @@ h2 {
     display: grid;
     place-items: center;
     background-color: #111827;
-    border: 1px solid #ffffff2f;
-    border-radius: 12px;
+    border: 0.0625em solid #ffffff2f;
+    border-radius: 0.75em;
     font-weight: 600;
     transition: border-color .15s, box-shadow .15s, background .15s, transform .02s;
 }
@@ -100,31 +100,31 @@ h2 {
 }
 
 .seg-item>input:focus-visible+span {
-    outline: 2px solid $primary-light;
-    outline-offset: 2px;
+    outline: 0.125em solid $primary-light;
+    outline-offset: 0.125em;
 }
 
 .seg-item>input:checked+span {
     border-color: $primary-light;
-    box-shadow: 0 0 0 4px rgba(63, 81, 181, .12);
+    box-shadow: 0 0 0 0.25em rgba(63, 81, 181, .12);
     background-color: darken($primary, 25%);
 }
 
 .seg-item>input:checked+span::after {
     content: '✓';
     position: absolute;
-    top: 6px;
-    right: 6px;
+    top: 0.375em;
+    right: 0.375em;
     background: $primary;
     color: #fff;
-    width: 20px;
-    height: 20px;
+    width: 1.25em;
+    height: 1.25em;
     border-radius: 50%;
     display: grid;
     place-items: center;
     font-size: 1em;
     font-weight: 700;
-    box-shadow: 0 0 0 2px #111827;
+    box-shadow: 0 0 0 0.125em #111827;
     opacity: 0;
     transform: scale(0.5);
     animation: checkPop .25s forwards ease-out;
@@ -132,14 +132,14 @@ h2 {
 
 .primary {
     text-align: center;
-    height: 44px;
+    height: 2.75em;
     border: none;
     font-weight: 700;
     background: $primary;
     color: #fff;
     cursor: pointer;
     transition: transform .02s, filter .15s, box-shadow .15s;
-    box-shadow: 0 6px 18px rgba(63, 81, 181, .25);
+    box-shadow: 0 0.375em 1.125em rgba(63, 81, 181, .25);
 }
 
 .primary:disabled {
@@ -149,15 +149,15 @@ h2 {
 }
 
 .primary:active {
-    transform: translateY(1px);
+    transform: translateY(0.0625em);
 }
 
 .preview {
-    margin: 6px 0 0;
+    margin: 0.375em 0 0;
     background: #0f172a;
     color: #e5e7eb;
-    padding: 10px 12px;
-    border-radius: 10px;
+    padding: 0.625em 0.75em;
+    border-radius: 0.625em;
     font-size: .85rem;
     overflow: auto;
 }
@@ -170,10 +170,10 @@ h2 {
     display: flex;
     white-space: nowrap;
     height: 100%;
-    min-height: 100px;
+    min-height: 6.25em;
 
     span {
-        padding: 5px;
+        padding: 0.3125em;
         text-align: center;
         background: $dark;
         position: absolute;
@@ -185,21 +185,21 @@ h2 {
 
     img,
     svg {
-        transform: translate(0, 7px);
+        transform: translate(0, 0.4375em);
     }
 
     svg {
-        transform: translate(7px, 15px);
+        transform: translate(0.4375em, 0.9375em);
     }
 }
 
 [type=text] {
     all: unset;
-    border-radius: 10px;
-    padding: 5px;
-    border: 1px solid #ffffff62;
+    border-radius: 0.625em;
+    padding: 0.3125em;
+    border: 0.0625em solid #ffffff62;
     background-color: #111827;
-    min-height: 50px;
+    min-height: 3.125em;
 
 }
 
@@ -223,11 +223,11 @@ h2 {
     color: #ffffff;
     font-size: 0.75em;
     font-weight: 200;
-    filter: drop-shadow(0 0 10px #000000);
+    filter: drop-shadow(0 0 0.625em #000000);
     opacity: 1;
 
     i {
-        margin: 5px;
+        margin: 0.3125em;
     }
 }
 
@@ -257,8 +257,8 @@ h2 {
     border-radius: $border-radius;
     padding: 1em 1em;
     color: $primary-ultra-light;
-    box-shadow: 0 8px 30px rgba(0, 0, 0, .4);
-    border: 1px solid rgba($primary-light, 0.2);
+    box-shadow: 0 0.5em 1.875em rgba(0, 0, 0, .4);
+    border: 0.0625em solid rgba($primary-light, 0.2);
 
     h3 {
         font-size: 1.4rem;
@@ -266,7 +266,7 @@ h2 {
         margin-bottom: 1rem;
         color: $primary-light;
         text-align: center;
-        letter-spacing: 0.5px;
+        letter-spacing: 0.0312em;
     }
 
     ul {
@@ -276,8 +276,8 @@ h2 {
 
         li {
             background: rgba($dark2, 0.8);
-            border: 1px solid rgba($primary-light, 0.15);
-            border-radius: 10px;
+            border: 0.0625em solid rgba($primary-light, 0.15);
+            border-radius: 0.625em;
             padding: 0.8rem 1rem;
             margin-bottom: 0.8rem;
             font-size: 0.95rem;
@@ -290,7 +290,7 @@ h2 {
 
             &:hover {
                 background: rgba($primary, 0.2);
-                transform: translateY(-2px);
+                transform: translateY(-0.125em);
             }
 
             &::before {
@@ -302,7 +302,7 @@ h2 {
     }
 }
 
-@media screen and (max-width: 600px) {
+@media screen and (max-width: 37.5em) {
     .not-available {
         flex-direction: column;
     }

--- a/src/app/components/competitions/competition-detail/competition-detail.component.html
+++ b/src/app/components/competitions/competition-detail/competition-detail.component.html
@@ -46,7 +46,7 @@
     </div>
     <div class="d-flex flex-column">
       <div>
-        <div style="min-width: 150px">
+        <div style="min-width: 9.375em">
           <button class="button-primary-ping" (click)="modalService.openModal(modalService.MODALS['ADD_PLAYERS'])">
             {{ "add_players" | translate }}
             <i class="fa-solid fa-users ms-2"></i>

--- a/src/app/components/competitions/competition-detail/competition-detail.component.scss
+++ b/src/app/components/competitions/competition-detail/competition-detail.component.scss
@@ -3,12 +3,12 @@
 .competition-detail {
   padding: 3em;
   border-radius: $border-radius;
-  filter: drop-shadow(10px 10px solid black);
+  filter: drop-shadow(0.625em 0.625em solid black);
   position: relative;
-  max-width: 600px;
+  max-width: 37.5em;
   margin: auto;
   background: $dark;
-  filter: drop-shadow(0px 0px 10px black);
+  filter: drop-shadow(0em 0em 0.625em black);
 }
 
 .top {
@@ -56,7 +56,7 @@
   display: grid;
   grid-auto-flow: column;
   grid-auto-columns: 1fr;
-  gap: 10px;
+  gap: 0.625em;
 }
 
 .players-container {
@@ -77,15 +77,15 @@
 .invitation-code-container {
   font-size: 0.7em;
   background-color: black;
-  filter: drop-shadow(0px 0px 5px $secondary);
+  filter: drop-shadow(0em 0em 0.3125em $secondary);
   border-radius: $border-radius;
   text-align: center;
   padding: 1em;
-  width: 150px;
+  width: 9.375em;
 
   .value {
     font-size: 1em;
     text-transform: uppercase;
-    letter-spacing: 2px;
+    letter-spacing: 0.125em;
   }
 }

--- a/src/app/components/competitions/competitions/competitions.component.html
+++ b/src/app/components/competitions/competitions/competitions.component.html
@@ -72,14 +72,14 @@
         <!-- Bottoni -->
         <section>
             <div class="buttons-add">
-                <div class="button-container" style="max-width: 600px;">
+                <div class="button-container" style="max-width: 37.5em;">
                     <button class="button-primary-ping secondary-color-button"
                         (click)="modalService.openModal(modalService.MODALS['JOIN_COMPETITION'])">
                         <div class="m-1">{{ "join_cta" | translate }}</div>
                         <i class="fa-solid fa-share"></i>
                     </button>
                 </div>
-                <div class="button-container" style="max-width: 600px;">
+                <div class="button-container" style="max-width: 37.5em;">
                     <button class="button-primary-ping"
                         (click)="modalService.openModal(modalService.MODALS['ADD_COMPETITION'])">
                         <div class="m-1">{{ "create_cta" | translate }}</div>

--- a/src/app/components/competitions/competitions/competitions.component.scss
+++ b/src/app/components/competitions/competitions/competitions.component.scss
@@ -8,14 +8,14 @@
         margin: 0;
 
         button {
-            width: 275px;
+            width: 17.1875em;
             margin: none;
             margin-bottom: 1em;
-            padding: 5px;
+            padding: 0.3125em;
         }
     }
 
-    max-width: 600px;
+    max-width: 37.5em;
     margin: auto;
 }
 
@@ -23,7 +23,7 @@
     .comp {
         background: $dark;
         border-radius: $border-radius;
-        filter: drop-shadow(0px 0px 10px black);
+        filter: drop-shadow(0em 0em 0.625em black);
         padding: 1em;
         padding-bottom: 2em;
 
@@ -58,7 +58,7 @@
     display: grid;
     gap: 1em;
     grid-template-columns: repeat(3, 1fr);
-    max-width: 600px;
+    max-width: 37.5em;
     margin: auto;
 }
 
@@ -69,8 +69,8 @@
 
 .players-count {
     position: absolute;
-    bottom: 5px;
-    left: 5px;
+    bottom: 0.3125em;
+    left: 0.3125em;
     font-size: 0.7em;
     margin-right: 0.5em;
     display: inline-block;
@@ -87,7 +87,7 @@
     padding: 0.5em;
     margin-top: 1em;
     white-space: nowrap;
-    height: 50px;
+    height: 3.125em;
 
     p {
         font-size: 0.7em;
@@ -95,8 +95,8 @@
     }
 
     img {
-        max-width: 30px;
-        max-height: 30px;
+        max-width: 1.875em;
+        max-height: 1.875em;
     }
 
 }
@@ -111,7 +111,7 @@ app-dropdown {
     right: 0;
 }
 
-@media screen and (max-width: 600px) {
+@media screen and (max-width: 37.5em) {
     .other-competitions-container {
         grid-template-columns: 1fr;
         margin: auto;
@@ -125,7 +125,7 @@ app-dropdown {
     }
 }
 
-@media screen and (max-width: 650px) {
+@media screen and (max-width: 40.625em) {
     .buttons-add {
         display: block;
 

--- a/src/app/components/home.component.scss
+++ b/src/app/components/home.component.scss
@@ -1,5 +1,5 @@
-@media screen and (max-width: 1000px) {
+@media screen and (max-width: 62.5em) {
     .wrapper {
-        margin-top: 75px;
+        margin-top: 4.6875em;
     }
 }

--- a/src/app/components/join-competition-modal/join-competition-modal.component.html
+++ b/src/app/components/join-competition-modal/join-competition-modal.component.html
@@ -7,7 +7,7 @@
                 <input id="competitionId" [placeholder]="'ex. ABC123' | translate" type="text"
                     [(ngModel)]="competitionCode" name="competitionCode" required>
                 <div class="">
-                    <button type="button" (click)="onSubmit()" style="height: 40px;">
+                    <button type="button" (click)="onSubmit()" style="height: 2.5em;">
                         {{ 'join_cta2' | translate }}
                     </button>
                 </div>

--- a/src/app/components/join-competition-modal/join-competition-modal.component.scss
+++ b/src/app/components/join-competition-modal/join-competition-modal.component.scss
@@ -7,13 +7,13 @@
     }
     input {
         text-align: center;
-        width: 230px;
+        width: 14.375em;
         margin-top: 1em;
     }
 
     button {
         text-align: center;
-        width: 200px;
+        width: 12.5em;
         background-color: $secondary!important;
     }
     .where {

--- a/src/app/components/matches/matches.component.scss
+++ b/src/app/components/matches/matches.component.scss
@@ -1,15 +1,15 @@
 @use '../../../style/variables.scss' as *;
 .match {
-    max-width: 250px;
+    max-width: 15.625em;
     border-radius: $border-radius;
     background: $gradient;    
     color: white;
-    padding: 20px;
+    padding: 1.25em;
     margin: 0 0.5em;
 
     img {
-        width: 50px;
-        height: 50px;
+        width: 3.125em;
+        height: 3.125em;
         object-fit: cover;
         border-radius: 50%;
     }
@@ -42,5 +42,5 @@
     text-align: center;
     opacity: 0.7;
     position: relative;
-    bottom: 10px;
+    bottom: 0.625em;
 }

--- a/src/app/components/profile/complete-profile/complete-profile.component.scss
+++ b/src/app/components/profile/complete-profile/complete-profile.component.scss
@@ -2,7 +2,7 @@
   display: block;
   position: absolute;
   content: attr(data-tooltip);
-  border: 1px solid black;
+  border: 0.0625em solid black;
   background: #eee;
   padding: .25em;
 }
@@ -14,8 +14,8 @@ input[type="file"] {
 .custom-file-upload {
   display: block;
   text-align: center;
-  width: 100px;
-  height: 100px;
+  width: 6.25em;
+  height: 6.25em;
   border-radius: 50%;
   display: inline-block;
   cursor: pointer;
@@ -46,7 +46,7 @@ input[type="file"] {
     bottom: 15%;
     font-size: 2em;
     opacity: 0.75;
-    filter: drop-shadow(0 0 2px white);
+    filter: drop-shadow(0 0 0.125em white);
     transition: all 0.2s ease-in-out;
   }
 

--- a/src/app/components/profile/profile/profile.component.scss
+++ b/src/app/components/profile/profile/profile.component.scss
@@ -2,7 +2,7 @@
   display: block;
   position: absolute;
   content: attr(data-tooltip);
-  border: 1px solid black;
+  border: 0.0625em solid black;
   background: #eee;
   padding: .25em;
 }
@@ -14,8 +14,8 @@ input[type="file"] {
 .custom-file-upload {
   display: block;
   text-align: center;
-  width: 100px;
-  height: 100px;
+  width: 6.25em;
+  height: 6.25em;
   border-radius: 50%;
   display: inline-block;
   cursor: pointer;
@@ -47,7 +47,7 @@ input[type="file"] {
     font-size: 2em;
     opacity: 0.75;
     transition: all 0.2s ease-in-out;
-    filter: drop-shadow(0 0 2px white);
+    filter: drop-shadow(0 0 0.125em white);
   }
 
   color: black;

--- a/src/app/components/show-match-modal/show-match-modal.component.scss
+++ b/src/app/components/show-match-modal/show-match-modal.component.scss
@@ -39,20 +39,20 @@
 
   img {
     height: 100%;
-    border-radius: 500px;
+    border-radius: 31.25em;
     object-fit: cover;
     width: 5em;
     height: 5em;
 
     &.logo {
-      width: 50px;
-      height: 50px;
+      width: 3.125em;
+      height: 3.125em;
     }
   }
 
   .set {
     display: grid;
-    grid-template-columns: auto 80px auto;
+    grid-template-columns: auto 5em auto;
     margin-bottom: 0.5em;
     border-radius: $border-radius;
     position: relative;
@@ -66,16 +66,16 @@
     .separator {
       font-weight: 100;
       color: $primary;
-      font-size: 12px;
+      font-size: 0.75em;
     }
 
     .n-set {
       color: white;
-      transform: scale(0.8) translateX(5px);
+      transform: scale(0.8) translateX(0.3125em);
       font-weight: 100;
       font-style: italic;
       position: absolute;
-      font-size: 9px;
+      font-size: 0.5625em;
     }
   }
 
@@ -97,7 +97,7 @@
     text-align: center;
     opacity: 0.7;
     position: relative;
-    bottom: 10px;
+    bottom: 0.625em;
   }
 
   .score.won {
@@ -108,12 +108,12 @@
 
 
 
-@media screen and (max-width:500px) {
+@media screen and (max-width:31.25em) {
   .dettagli-partita {
     .match-container {
       img {
-        width: 50px;
-        height: 50px;
+        width: 3.125em;
+        height: 3.125em;
       }
     }
   }

--- a/src/app/utils/Slider.ts
+++ b/src/app/utils/Slider.ts
@@ -31,6 +31,10 @@ export class Slider {
     this.addEventListeners();
   }
 
+  private pxToEm(value: number): string {
+    return `${value / 16}em`;
+  }
+
   public updateUI(): void {
     this.updateSliderPosition();
     this.updateArrowState();
@@ -65,7 +69,7 @@ export class Slider {
       if (!moving) return;
       const currentX = e.touches[0].pageX;
       const translateX = this.newPosition + currentX - startX;
-      this.matchesSlider.style.transform = `translateX(${translateX}px)`;
+      this.matchesSlider.style.transform = `translateX(${this.pxToEm(translateX)})`;
     });
 
     this.matchesSlider.addEventListener("touchend", (e: TouchEvent) => {
@@ -89,9 +93,9 @@ export class Slider {
 
     this.matchesSlider.addEventListener("mousemove", (e: MouseEvent) => {
       if (!this.dragging) return;
-      const currentX = e.pageX;
-      const translateX = this.newPosition + currentX - this.startX;
-      this.matchesSlider.style.transform = `translateX(${translateX}px)`;
+        const currentX = e.pageX;
+        const translateX = this.newPosition + currentX - this.startX;
+        this.matchesSlider.style.transform = `translateX(${this.pxToEm(translateX)})`;
     });
 
     this.matchesSlider.addEventListener("mouseup", (e: MouseEvent) => {
@@ -139,7 +143,7 @@ export class Slider {
     const maxSlide = this.matchesSlider.scrollWidth - this.matchesSlider.offsetWidth;
     this.newPosition = Math.max(-(this.index * matchTotalWidth), -maxSlide);
     this.matchesSlider.style.transition = "transform 0.3s ease-out";
-    this.matchesSlider.style.transform = `translateX(${this.newPosition}px)`;
+    this.matchesSlider.style.transform = `translateX(${this.pxToEm(this.newPosition)})`;
   }
 
   private handleArrowClick(direction: "left" | "right"): void {

--- a/src/app/utils/components/loader/loader.component.html
+++ b/src/app/utils/components/loader/loader.component.html
@@ -10,7 +10,7 @@
 </div>
 
 <div *ngIf="isSmallLoading" class="loader-small">
-  <div class="d-flex ms-3 align-items-center" style="gap: 5px; min-height: 40px;">
+  <div class="d-flex ms-3 align-items-center" style="gap: 0.3125em; min-height: 2.5em;">
     <div class="ping-ball a"></div>
     <div class="ping-ball b"></div>
     <div class="ping-ball c"></div>

--- a/src/app/utils/components/loader/loader.component.scss
+++ b/src/app/utils/components/loader/loader.component.scss
@@ -6,9 +6,9 @@
   left: 50%;
   transform: translate(-50%, -50%);
   background: white;
-  padding: 20px;
-  box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.1);
-  border-radius: 5px;
+  padding: 1.25em;
+  box-shadow: 0em 0em 0.625em rgba(0, 0, 0, 0.1);
+  border-radius: 0.3125em;
   z-index: 1000;
   padding: 0;
   width: 100vw;
@@ -40,7 +40,7 @@
   margin: 1em;
   background-color: $green;
   color: black;
-  box-shadow: 0px 0px 5px black;
+  box-shadow: 0em 0em 0.3125em black;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -68,7 +68,7 @@
     all: unset;
     padding: 1em 1.5em;
     cursor: pointer;
-    border-left: 1px solid #00000017;
+    border-left: 0.0625em solid #00000017;
   }
 }
 
@@ -82,16 +82,16 @@
   padding: 1em 2em;
   bottom: 0;
   right: 0;
-  filter: drop-shadow(0px 0px 5px black);
+  filter: drop-shadow(0em 0em 0.3125em black);
 }
 
 .ping-ball {
-  width: 20px;
-  height: 20px;
+  width: 1.25em;
+  height: 1.25em;
   background-color: white;
   border-radius: 50%;
   animation: ping-bounce 1s infinite linear;
-  filter: drop-shadow(0px 0px 5px black);
+  filter: drop-shadow(0em 0em 0.3125em black);
   transform: scale(0.5);
   &.a {
     animation-delay: 0s;
@@ -138,10 +138,10 @@
     transform: translateY(60%) scale(0.5) skewX(0deg) rotate(0deg);
   }
 }
-@media screen and (max-width: 768px) {
+@media screen and (max-width: 48em) {
   .loader-small {
     padding: 0.5em 1em;
-    bottom: 100px;
+    bottom: 6.25em;
     left: 50%;
     transform: translateX(-50%);
   }

--- a/src/debug-overlay/debug-overlay.component.html
+++ b/src/debug-overlay/debug-overlay.component.html
@@ -24,7 +24,7 @@
             <strong>Active competition:</strong>
             {{ activeCompetition$ | async | json }}
         </div>
-        <button class="close" (click)="close()" style="position: absolute; top: 5px; right: 5px;">
+        <button class="close" (click)="close()" style="position: absolute; top: 0.3125em; right: 0.3125em;">
             <i class="fa-solid fa-xmark"></i>
         </button>
     </ng-container>

--- a/src/debug-overlay/debug-overlay.component.scss
+++ b/src/debug-overlay/debug-overlay.component.scss
@@ -4,16 +4,16 @@
     right: 0;
     background: rgba(0, 0, 0, 0.85);
     color: #0f0;
-    font-size: 11px;
+    font-size: 0.6875em;
     line-height: 1.3;
-    padding: 6px 10px;
+    padding: 0.375em 0.625em;
     z-index: 9999;
-    max-width: 240px;
-    border-bottom-left-radius: 8px;
+    max-width: 15em;
+    border-bottom-left-radius: 0.5em;
 
     pre {
         margin: 0;
-        font-size: 10px;
+        font-size: 0.625em;
         white-space: pre-wrap;
         word-break: break-word;
     }

--- a/src/services/modal.service.ts
+++ b/src/services/modal.service.ts
@@ -32,9 +32,9 @@ export class ModalService {
 
   setEffects() {
     document?.querySelector('html')?.style.setProperty('overflow', 'hidden');
-    document?.querySelector('html')?.style.setProperty('margin-right', '7px');
+    document?.querySelector('html')?.style.setProperty('margin-right', '0.4375em');
     let wrapper = document.querySelector('.wrapper') as HTMLElement;
-    wrapper?.style.setProperty('filter', 'blur(10px)');
+    wrapper?.style.setProperty('filter', 'blur(0.625em)');
     wrapper?.style.setProperty('pointer-events', 'none');
     wrapper?.style.setProperty('user-select', 'none');
   }

--- a/src/style/animations.scss
+++ b/src/style/animations.scss
@@ -33,7 +33,7 @@
     }
 }
 
-@media screen and (max-width: 600px) {
+@media screen and (max-width: 37.5em) {
     .my-modal:not(.small) {
         opacity: 0;
         animation: openMobile 0.1s ease-out forwards;

--- a/src/style/forms.scss
+++ b/src/style/forms.scss
@@ -50,7 +50,7 @@ $border: #1f2937;
   box-sizing: border-box;
 
   background: $field;
-  border: 1px solid $border;
+  border: 0.0625em solid $border;
   border-radius: $border-radius;
 
   color: $text;
@@ -131,7 +131,7 @@ $border: #1f2937;
 
   background: $field;
   color: $text;
-  border: 1px solid $border;
+  border: 0.0625em solid $border;
   border-radius: $border-radius;
   text-align: center;
   overflow: hidden;
@@ -139,8 +139,8 @@ $border: #1f2937;
 
   .search-icon {
     position: absolute;
-    right: 10px;
-    top: 7px;
+    right: 0.625em;
+    top: 0.4375em;
   }
 
   .player-item {
@@ -159,7 +159,7 @@ $border: #1f2937;
 .dropdown.visible {
   visibility: visible;
   opacity: 1;
-  transform: translateY(-12px);
+  transform: translateY(-0.75em);
   width: 45%;
 }
 
@@ -174,20 +174,20 @@ $border: #1f2937;
   }
 
   .input-container {
-    min-width: 70px;
-    max-width: 80px;
+    min-width: 4.375em;
+    max-width: 5em;
     margin: .1rem .5rem .1rem .1rem;
   }
 }
 
 /* Bordo arrotondato top/bottom in stack */
 form .input-top {
-  border-radius: 20px 20px 0 0;
+  border-radius: 1.25em 1.25em 0 0;
   margin-bottom: 0;
 }
 
 form .input-bottom {
-  border-radius: 0 0 20px 20px;
+  border-radius: 0 0 1.25em 1.25em;
   margin-bottom: 0;
 }
 
@@ -207,14 +207,14 @@ form .input-bottom {
     position: absolute;
     content: attr(title);
     background-color: black;
-    filter: drop-shadow(0 0 5px rgba(0, 0, 0, 0.5));
+    filter: drop-shadow(0 0 0.3125em rgba(0, 0, 0, 0.5));
     border-radius: $border-radius;
     z-index: 900;
   }
 }
 
 /* Mobile */
-@media (max-width: 768px) {
+@media (max-width: 48em) {
   .input-field {
     overflow: hidden;
     white-space: nowrap;
@@ -227,7 +227,7 @@ form .input-bottom {
 
 /* Wrapper punti */
 .wrapper-points .input-container {
-  padding: 3px;
+  padding: 0.1875em;
 }
 
 .form-control input-field {
@@ -243,8 +243,8 @@ input[type="file"]::file-selector-button {
   background: $primary;
   color: white;
   border: none;
-  padding: 6px 12px;
-  border-radius: 4px;
+  padding: 0.375em 0.75em;
+  border-radius: 0.25em;
   cursor: pointer;
 
 }
@@ -258,8 +258,8 @@ input[type="file"]::-webkit-file-upload-button {
   background: $primary;
   color: white;
   border: none;
-  padding: 6px 12px;
-  border-radius: 4px;
+  padding: 0.375em 0.75em;
+  border-radius: 0.25em;
   cursor: pointer;
   transition: all .2s ease;
 }

--- a/src/style/slider.scss
+++ b/src/style/slider.scss
@@ -19,14 +19,14 @@
 
 .arrow {
     padding: 1em;
-    width: 50px;
-    height: 50px;
+    width: 3.125em;
+    height: 3.125em;
     display: flex;
     justify-content: center;
     align-items: center;
     background-color: var(--primary);
     border-radius: 50%;
-    filter: drop-shadow(0 0 10px #000000);
+    filter: drop-shadow(0 0 0.625em #000000);
     cursor: pointer;
 }
 
@@ -41,9 +41,9 @@
 }
 
 .arrow-left {
-    left: 5px;
+    left: 0.3125em;
 }
 
 .arrow-right {
-    right: 5px;
+    right: 0.3125em;
 }

--- a/src/style/style.scss
+++ b/src/style/style.scss
@@ -27,12 +27,12 @@ main {
 }
 
 #page-container {
-    padding-top: 75px;
+    padding-top: 4.6875em;
 }
 
 // Navigation
 nav {
-    height: 75px;
+    height: 4.6875em;
     background-color: $dark;
     color: white;
     font-size: 1em;
@@ -54,7 +54,7 @@ nav {
     }
 
     .logo {
-        max-width: 75px;
+        max-width: 4.6875em;
     }
 
     .title {
@@ -64,10 +64,10 @@ nav {
 
         span {
             display: inline-block;
-            width: 10px;
-            height: 10px;
+            width: 0.625em;
+            height: 0.625em;
             background-color: var(--orange);
-            border-radius: 10px;
+            border-radius: 0.625em;
         }
     }
 
@@ -80,7 +80,7 @@ h2 {
     color: white;
     font-family: LarkenRegular;
     font-weight: 300;
-    letter-spacing: -0.5px;
+    letter-spacing: -0.0312em;
     font-family: LarkenRegular, sans-serif;
     font-weight: 100;
     text-align: center;
@@ -91,7 +91,7 @@ h3 {
     color: white;
     font-family: LarkenRegular;
     font-weight: 300;
-    letter-spacing: -0.5px;
+    letter-spacing: -0.0312em;
     font-family: LarkenRegular, sans-serif;
     font-weight: 100;
     text-align: center;
@@ -99,7 +99,7 @@ h3 {
 
 // Buttons
 .button-container {
-    max-width: 500px;
+    max-width: 31.25em;
     margin: auto;
     padding: 1em;
 
@@ -113,7 +113,7 @@ h3 {
         background-color: $primary;
         color: $primary-ultra-light;
         width: 100%;
-        min-height: 50px;
+        min-height: 3.125em;
         transition: transform 0.1s ease-in-out;
 
         &:hover {
@@ -133,7 +133,7 @@ h3 {
     background-color: $primary;
     color: $primary-ultra-light;
     width: 100%;
-    min-height: 50px;
+    min-height: 3.125em;
     transition: transform 0.1s ease-in-out;
 
     &>div {
@@ -149,14 +149,14 @@ h3 {
     all: unset;
     cursor: pointer;
     border-radius: $border-radius;
-    width: 150px;
-    height: 150px;
+    width: 9.375em;
+    height: 9.375em;
     display: flex;
     justify-content: center;
     align-items: center;
     flex-direction: column;
     transition: transform 0.1s ease-in-out;
-    filter: drop-shadow(0px 0px 10px #00000075);
+    filter: drop-shadow(0em 0em 0.625em #00000075);
     position: relative;
     overflow: hidden;
     background-color: #0b1e2a;
@@ -207,8 +207,8 @@ section {
 
 // Scrollbar Styling
 ::-webkit-scrollbar {
-    width: 7px;
-    height: 7px;
+    width: 0.4375em;
+    height: 0.4375em;
 }
 
 ::-webkit-scrollbar-track {
@@ -217,7 +217,7 @@ section {
 
 ::-webkit-scrollbar-thumb {
     background: #ffffff31;
-    border-radius: 5px;
+    border-radius: 0.3125em;
 
     &:hover {
         background: $primary;
@@ -227,26 +227,26 @@ section {
 
 
 .wrapper-points {
-    min-height: 102px;
+    min-height: 6.375em;
 }
 
 [data-toggle] {
     cursor: cell;
 }
 
-@media screen and (min-width: 1000px) {
+@media screen and (min-width: 62.5em) {
     nav {
         height: $navbar-height;
     }
 
     #page-container {
-        padding-top: 100px;
+        padding-top: 6.25em;
     }
 }
 
 .avatar {
-    width: 75px;
-    height: 75px;
+    width: 4.6875em;
+    height: 4.6875em;
     border-radius: 50%;
     object-fit: cover;
 }
@@ -254,17 +254,17 @@ section {
 .my-modal {
     display: block;
     position: fixed;
-    top: calc(50% + 35px);
+    top: calc(50% + 2.1875em);
     left: 50%;
     transform: translate(-50%, -50%);
     z-index: 102;
     background: $gradient-reverse;
     color: white; // Ensure text is visible on black background
     border-radius: $border-radius;
-    box-shadow: 0 0 25px black;
+    box-shadow: 0 0 1.5625em black;
     padding: 1em;
     width: 90vw;
-    max-width: 700px;
+    max-width: 43.75em;
     max-height: 85vh;
     overflow: auto;
 
@@ -295,8 +295,8 @@ section {
         overflow: hidden;
 
         &.close {
-            width: 25px;
-            height: 25px;
+            width: 1.5625em;
+            height: 1.5625em;
             display: flex;
             justify-content: center;
             align-items: center;
@@ -306,7 +306,7 @@ section {
             top: 0;
             left: 100%;
             transition: all 0.1s ease-in-out;
-            filter: drop-shadow(0px 0px 10px #282828);
+            filter: drop-shadow(0em 0em 0.625em #282828);
             z-index: 10;
 
             &:hover {
@@ -365,8 +365,8 @@ button.secondary-color-button {
 }
 
 .icon {
-    width: 32px;
-    height: 32px;
+    width: 2em;
+    height: 2em;
     object-fit: cover;
 }
 
@@ -378,7 +378,7 @@ button.secondary-color-button {
     background-color: $secondary !important;
 }
 
-@media screen and (max-width: 600px) {
+@media screen and (max-width: 37.5em) {
     .my-modal:not(.small) {
         top: 0;
         left: 0;

--- a/src/style/utility.scss
+++ b/src/style/utility.scss
@@ -30,27 +30,27 @@ label.field {
         opacity: 0.8;
     }
     position: absolute;
-    bottom: -2px;
-    right: 10px;
+    bottom: -0.125em;
+    right: 0.625em;
 }
 
 .my-container {
-    max-width: 800px;
+    max-width: 50em;
     margin: auto;
 }
 
 .wrapper {
     margin-top: $navbar-height;
     padding-top: 1em;
-    padding-bottom: 150px;
+    padding-bottom: 9.375em;
     transition: filter 0.25s ease-in-out;
     overflow-y: scroll;
 }
 
-@media screen and (max-width: 530px) {
+@media screen and (max-width: 33.125em) {
     .marquee {
         width: 100%;
-        height: 28px;
+        height: 1.75em;
         overflow: hidden;
         white-space: nowrap;
         position: relative;
@@ -91,14 +91,14 @@ label.field {
 
 p.instructions {
     text-align: center;
-    max-width: 500px;
+    max-width: 31.25em;
     margin: auto;
 }
 
 small.error {
     display: block;
     text-align: left;
-    width: 200px;
+    width: 12.5em;
     font-size: 0.75em;
 }
 

--- a/src/style/variables.scss
+++ b/src/style/variables.scss
@@ -22,8 +22,8 @@ $orange: #ffa10b; // Ho allineato $orange a $light per coerenza, se sono intesi 
 // Gradiente Speciale (ho mantenuto la tua struttura, ma ho usato $dark-blu come base per renderlo più coerente)
 $gradient2: linear-gradient(90deg, #192745c8 0%, #122137 50%, $dark 100%);
 
-$border-radius : 12px;
-$navbar-height: 75px;
+$border-radius : 0.75em;
+$navbar-height: 4.6875em;
 
 :root {
   --dark: #05131c;
@@ -33,12 +33,12 @@ $navbar-height: 75px;
   --contrast: #c76360;
   --secondary: #e19945;
   --light: #f2c373;
-  --border-radius: 30px;
+  --border-radius: 1.875em;
   --green: #4e9f6b;
   --orange: #ffa10b;
   --gradient: linear-gradient(180deg, black 10%, #05131c 90%);
   --gradient-reverse: linear-gradient(180deg, #05131c 10%, black 90%);
-  --border-radius: 30px;
+  --border-radius: 1.875em;
 }
 
 @keyframes bounce {
@@ -49,6 +49,6 @@ $navbar-height: 75px;
   }
 
   50% {
-    transform: translateX(-50%) translateY(-50px);
+    transform: translateX(-50%) translateY(-3.125em);
   }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -14,14 +14,14 @@
     color: white;
 }
 
-@media (max-width: 600px) {
+@media (max-width: 37.5em) {
     body {
-        font-size: 12px;
+        font-size: 0.75em;
     }
 }
 
-@media (min-width: 1200px) {
+@media (min-width: 75em) {
     body {
-        font-size: 17px;
+        font-size: 1.0625em;
     }
 }


### PR DESCRIPTION
## Summary
- replace pixel values with `em` across styles and templates for scalable sizing
- update runtime style logic to emit `em` units instead of `px`

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68c1fd1b4af48322940b5e596505fbc1