### PR TITLE
Fix active competition persistence for id zero

### DIFF
--- a/src/services/competitions.service.ts
+++ b/src/services/competitions.service.ts
@@ -29,7 +29,7 @@ export class CompetitionService {
 
     // 2. Altrimenti usa lo userState
     const state = this.user?.snapshot();
-    if (state?.active_competition_id) {
+    if (state?.active_competition_id !== null && state?.active_competition_id !== undefined) {
       return this.store.snapshotById(state.active_competition_id) ?? null;
     }
 

--- a/src/stores/competition.store.ts
+++ b/src/stores/competition.store.ts
@@ -38,7 +38,7 @@ export class CompetitionStore {
   size$ = this._state$.pipe(map(s => s.ids.length));
 
   activeCompetition$ = this._state$.pipe(
-    map(s => (s.activeId ? s.entities[String(s.activeId)] ?? null : null))
+    map(s => (s.activeId !== null ? s.entities[String(s.activeId)] ?? null : null))
   );
 
   // ---------- SNAPSHOTS ----------
@@ -53,7 +53,7 @@ export class CompetitionStore {
 
   snapshotActive(): ICompetition | null {
     const s = this._state$.getValue();
-    return s.activeId ? s.entities[String(s.activeId)] ?? null : null;
+    return s.activeId !== null ? s.entities[String(s.activeId)] ?? null : null;
   }
 
   // ---------- COMMANDS ----------
@@ -104,10 +104,11 @@ export class CompetitionStore {
     console.log('[CompetitionStore] ✏️ updateFields', { id: sid, patch });
   }
 
-  setActive(id: Id | null) {
+  setActive(id: Id | null | undefined) {
     const prev = this._state$.getValue();
-    this._state$.next({ ...prev, activeId: id ? String(id) : null });
-    console.log('[CompetitionStore] ⭐ setActive', { id });
+    const nextId = id !== null && id !== undefined ? String(id) : null;
+    this._state$.next({ ...prev, activeId: nextId });
+    console.log('[CompetitionStore] ⭐ setActive', { id: nextId });
   }
 
   removeOne(id: Id) {


### PR DESCRIPTION
## Summary
- ensure the competition store keeps track of competition id 0 instead of resetting the active entry
- allow the competition service snapshot helper to resolve active competition id values equal to zero

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cad5d9c9948322a40abf8e46d892bb