### PR TITLE
Disable double tap zoom on mobile

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8" />
   <link rel="icon" type="image/svg+xml" href="/ping.svg" />
   <meta name="viewport"
-    content="initial-scale=1.0,minimum-scale=1.0,maximum-scale=1.0,width=device-width,height=device-height,target-densitydpi=device-dpi,user-scalable=yes" />
+    content="width=device-width,initial-scale=1.0,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link


### PR DESCRIPTION
## Summary
- prevent mobile browsers from triggering double-tap zoom by disabling page scaling in the viewport meta tag

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb3a7791c88322a5460278e0d28fd4