### PR TITLE
feat: add reusable loading button component

### DIFF
--- a/src/app/auth/login/login.component.html
+++ b/src/app/auth/login/login.component.html
@@ -15,7 +15,15 @@
             </div>
 
             <div class="mt-4 text-center">
-                  <button (click)="onLogin()" type="button" [disabled]="loginForm.invalid">{{ 'login' | translate }}</button>
+                  <app-loading-button
+                    class="mt-4 w-100"
+                    type="submit"
+                    variant="primary"
+                    [disabled]="loginForm.invalid"
+                    [linkToHttp]="true"
+                  >
+                    {{ 'login' | translate }}
+                  </app-loading-button>
                   <button id="googleBtn" type="button" (click)="googleSignIn($event)" class="mt-4"><img src="/google.png">{{ 'login_google' | translate }}</button>
             </div>
             <p class="mt-3 text-center">

--- a/src/app/auth/login/login.component.ts
+++ b/src/app/auth/login/login.component.ts
@@ -1,18 +1,18 @@
 import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { SupabaseAuthService } from '../../../services/supabase-auth.service';
 import { Router, RouterModule } from '@angular/router';
-import { CommonModule } from '@angular/common';
-import { TranslatePipe } from '../../utils/translate.pipe';
 import { NavbarComponent } from '../../common/navbar/navbar.component';
 import { RegistrationNavbarComponent } from './registration-navbar/registration-navbar.component';
 import { AuthService } from '../../../services/auth.service';
 import { LoaderService } from '../../../services/loader.service';
 import { MSG_TYPE } from '../../utils/enum';
+import { SHARED_IMPORTS } from '../../common/imports/shared.imports';
 
 @Component({
   selector: 'app-login',
-  imports: [CommonModule, FormsModule, ReactiveFormsModule, TranslatePipe, NavbarComponent, RegistrationNavbarComponent, RouterModule],
+  imports: [CommonModule, ...SHARED_IMPORTS, FormsModule, ReactiveFormsModule, NavbarComponent, RegistrationNavbarComponent, RouterModule],
   templateUrl: './login.component.html',
   styleUrl: './login.component.scss'
 })

--- a/src/app/common/badge/badge.component.ts
+++ b/src/app/common/badge/badge.component.ts
@@ -1,8 +1,10 @@
 import { Component, Input } from '@angular/core';
 
+import { CommonModule } from '@angular/common';
+
 @Component({
   selector: 'app-badge',
-  imports: [],
+  imports: [CommonModule],
   templateUrl: './badge.component.html',
   styleUrl: './badge.component.scss',
   standalone: true,

--- a/src/app/common/imports/shared.imports.ts
+++ b/src/app/common/imports/shared.imports.ts
@@ -1,7 +1,15 @@
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
+import { ReactiveFormsModule } from '@angular/forms';
 import { TranslatePipe } from '../../utils/translate.pipe';
 import { DropdownComponent } from '../dropdown/dropdown.component';
-import { ReactiveFormsModule } from '@angular/forms';
+import { LoadingButtonComponent } from '../loading-button/loading-button.component';
 
-export const SHARED_IMPORTS = [CommonModule, RouterModule, TranslatePipe, DropdownComponent, ReactiveFormsModule];
+export const SHARED_IMPORTS = [
+  CommonModule,
+  RouterModule,
+  TranslatePipe,
+  DropdownComponent,
+  ReactiveFormsModule,
+  LoadingButtonComponent,
+];

--- a/src/app/common/loading-button/loading-button.component.html
+++ b/src/app/common/loading-button/loading-button.component.html
@@ -1,0 +1,20 @@
+<button
+  class="loading-button"
+  [ngClass]="['variant-' + variant, isLoading ? 'is-loading' : null]"
+  [attr.type]="type"
+  [disabled]="disabled || isLoading"
+  [attr.aria-busy]="isLoading"
+  [attr.aria-live]="isLoading ? 'polite' : null"
+>
+  <span class="button-spinner" *ngIf="isLoading" aria-hidden="true">
+    <span class="loading-dot a"></span>
+    <span class="loading-dot b"></span>
+    <span class="loading-dot c"></span>
+  </span>
+  <span class="button-content" [class.loading]="isLoading">
+    <ng-container *ngIf="icon && !isLoading">
+      <i [ngClass]="icon" aria-hidden="true"></i>
+    </ng-container>
+    <span class="label"><ng-content></ng-content></span>
+  </span>
+</button>

--- a/src/app/common/loading-button/loading-button.component.scss
+++ b/src/app/common/loading-button/loading-button.component.scss
@@ -1,0 +1,137 @@
+@use '../../../style/variables' as *;
+
+:host {
+  display: inline-block;
+  width: auto;
+
+  &.w-100,
+  &.full-width {
+    width: 100%;
+  }
+}
+
+.loading-button {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5em;
+  width: 100%;
+  padding: 0.9em 1.5em;
+  border-radius: $border-radius;
+  border: none;
+  font-weight: 600;
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  cursor: pointer;
+  transition: transform 0.15s ease, opacity 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 0.5em 1.5em rgba(0, 0, 0, 0.25);
+  background: transparent;
+
+  &:hover:not(:disabled) {
+    transform: translateY(-0.05em) scale(0.99);
+  }
+
+  &:active:not(:disabled) {
+    transform: scale(0.97);
+  }
+
+  &:disabled,
+  &.is-loading {
+    cursor: not-allowed;
+    opacity: 0.7;
+    box-shadow: none;
+  }
+}
+
+.loading-button.variant-primary {
+  background: linear-gradient(135deg, $primary 0%, $secondary 100%);
+  color: $primary-ultra-light;
+
+  &:hover:not(:disabled) {
+    box-shadow: 0 0.75em 1.75em rgba(40, 74, 166, 0.35);
+  }
+}
+
+.loading-button.variant-secondary {
+  background: rgba($light, 0.15);
+  color: $primary-ultra-light;
+  border: 0.0625em solid rgba($primary-ultra-light, 0.4);
+
+  &:hover:not(:disabled) {
+    background: rgba($light, 0.25);
+  }
+}
+
+.loading-button.variant-link {
+  background: transparent;
+  color: $primary-light;
+  box-shadow: none;
+  padding-inline: 0.5em;
+  text-transform: none;
+  letter-spacing: normal;
+
+  &:hover:not(:disabled) {
+    text-decoration: underline;
+    transform: none;
+  }
+}
+
+.button-content {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5em;
+  transition: opacity 0.2s ease;
+
+  &.loading {
+    opacity: 0;
+  }
+
+  i {
+    font-size: 1.1em;
+  }
+}
+
+.button-spinner {
+  position: absolute;
+  inset: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.3em;
+}
+
+.loading-dot {
+  width: 0.5em;
+  height: 0.5em;
+  border-radius: 50%;
+  background-color: currentColor;
+  animation: loading-bounce 0.9s infinite ease-in-out;
+
+  &.a {
+    animation-delay: 0s;
+  }
+
+  &.b {
+    animation-delay: 0.15s;
+  }
+
+  &.c {
+    animation-delay: 0.3s;
+  }
+}
+
+@keyframes loading-bounce {
+  0%,
+  80%,
+  100% {
+    transform: translateY(0);
+    opacity: 0.6;
+  }
+
+  40% {
+    transform: translateY(-0.35em);
+    opacity: 1;
+  }
+}

--- a/src/app/common/loading-button/loading-button.component.ts
+++ b/src/app/common/loading-button/loading-button.component.ts
@@ -1,0 +1,77 @@
+import { booleanAttribute, Component, DestroyRef, Input, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { LoaderService } from '../../../services/loader.service';
+import { Subscription } from 'rxjs';
+
+type ButtonType = 'button' | 'submit' | 'reset';
+type ButtonVariant = 'primary' | 'secondary' | 'link';
+
+@Component({
+  selector: 'app-loading-button',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './loading-button.component.html',
+  styleUrls: ['./loading-button.component.scss']
+})
+export class LoadingButtonComponent {
+  @Input() type: ButtonType = 'button';
+  @Input() variant: ButtonVariant = 'primary';
+  @Input({ transform: booleanAttribute }) disabled = false;
+  @Input() icon?: string;
+
+  @Input({ transform: booleanAttribute })
+  set loading(value: boolean) {
+    this.explicitLoading = value;
+    this.updateLoadingState();
+  }
+
+  @Input({ transform: booleanAttribute })
+  set linkToHttp(value: boolean) {
+    if (this._linkToHttp === value) {
+      return;
+    }
+
+    this._linkToHttp = value;
+    this.configureHttpSubscription();
+    this.updateLoadingState();
+  }
+
+  protected isLoading = false;
+
+  private explicitLoading = false;
+  private serviceLoading = false;
+  private _linkToHttp = false;
+  private httpSubscription?: Subscription;
+
+  private readonly destroyRef = inject(DestroyRef);
+
+  constructor(private readonly loaderService: LoaderService) {}
+
+  private configureHttpSubscription(): void {
+    if (this._linkToHttp) {
+      if (this.httpSubscription) {
+        return;
+      }
+
+      this.httpSubscription = this.loaderService.isSmallLoading$.subscribe((isLoading) => {
+        this.serviceLoading = isLoading;
+        this.updateLoadingState();
+      });
+
+      this.destroyRef.onDestroy(() => {
+        this.httpSubscription?.unsubscribe();
+        this.httpSubscription = undefined;
+      });
+    } else {
+      if (this.httpSubscription) {
+        this.httpSubscription.unsubscribe();
+        this.httpSubscription = undefined;
+      }
+      this.serviceLoading = false;
+    }
+  }
+
+  private updateLoadingState(): void {
+    this.isLoading = this.serviceLoading || this.explicitLoading;
+  }
+}

--- a/src/app/components/profile/profile/profile.component.html
+++ b/src/app/components/profile/profile/profile.component.html
@@ -33,9 +33,16 @@
                 </div>
 
                 <div class="button-container">
-                    <button class="primary mt-3 w-100" (click)="saveProfile()" [disabled]="form?.invalid">
+                    <app-loading-button
+                        class="mt-3 w-100"
+                        variant="primary"
+                        [disabled]="form?.invalid"
+                        [linkToHttp]="true"
+                        icon="fa fa-save"
+                        (click)="saveProfile()"
+                    >
                         {{ 'edit' | translate }}
-                    </button>
+                    </app-loading-button>
                 </div>
             </form>
         </section>

--- a/src/app/components/profile/profile/profile.component.ts
+++ b/src/app/components/profile/profile/profile.component.ts
@@ -20,11 +20,12 @@ import { TranslatePipe } from '../../../utils/translate.pipe';
 import { BottomNavbarComponent } from '../../../common/bottom-navbar/bottom-navbar.component';
 import { PlayerDetailComponent } from './player-detail/player-detail.component';
 import { BadgeComponent } from '../../../common/badge/badge.component';
+import { LoadingButtonComponent } from '../../../common/loading-button/loading-button.component';
 
 @Component({
   selector: 'app-profile',
   standalone: true,
-  imports: [CommonModule, FormsModule, ReactiveFormsModule, NavbarComponent, TranslatePipe, BottomNavbarComponent, PlayerDetailComponent, BadgeComponent],
+  imports: [CommonModule, FormsModule, ReactiveFormsModule, NavbarComponent, TranslatePipe, BottomNavbarComponent, PlayerDetailComponent, BadgeComponent, LoadingButtonComponent],
   templateUrl: './profile.component.html',
   styleUrls: ['./profile.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,


### PR DESCRIPTION
## Summary
- add a standalone loading button component with optional icon, variants, and LoaderService linking
- expose the component through the shared imports and adopt it in the login and profile flows
- ensure BadgeComponent declares CommonModule so its structural directives are available

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb43fa525483229ffcbfde48b3f886