### PR TITLE
Add match management buttons to elimination bracket

### DIFF
--- a/public/lang.json
+++ b/public/lang.json
@@ -786,5 +786,17 @@
     "no": {
         "it": "No",
         "en": "No"
+    },
+    "quarterfinals": {
+        "it": "Quarti di finale",
+        "en": "Quarterfinals"
+    },
+    "semifinals": {
+        "it": "Semifinali",
+        "en": "Semifinals"
+    },
+    "final": {
+        "it": "Finale",
+        "en": "Final"
     }
 }

--- a/src/app/components/add-match-modal/add-match-modal.component.html
+++ b/src/app/components/add-match-modal/add-match-modal.component.html
@@ -10,11 +10,13 @@
         <!-- GIOCATORI -->
         <div class="row mt-3">
             <div class="col-md-6">
-                <app-select-player [players]="getPlayers(1)" [playerNumber]="'1'" (playerSelected)="setPlayer($event)">
+                <app-select-player [players]="getPlayers(1)" [playerNumber]="'1'" [initialPlayer]="player1"
+                    (playerSelected)="setPlayer($event)">
                 </app-select-player>
             </div>
             <div class="col-md-6">
-                <app-select-player [players]="getPlayers(2)" [playerNumber]="'2'" (playerSelected)="setPlayer($event)">
+                <app-select-player [players]="getPlayers(2)" [playerNumber]="'2'" [initialPlayer]="player2"
+                    (playerSelected)="setPlayer($event)">
                 </app-select-player>
             </div>
         </div>

--- a/src/app/components/add-match-modal/add-match-modal.component.ts
+++ b/src/app/components/add-match-modal/add-match-modal.component.ts
@@ -16,7 +16,7 @@ import { ICompetition } from '../../../api/competition.api';
 import { IPlayer } from '../../../services/players.service';
 
 @Component({
-  selector: 'app-add-match-modal',
+  selector: 'add-match-modal',
   standalone: true,
   templateUrl: './add-match-modal.component.html',
   styleUrls: ['./add-match-modal.component.scss'],
@@ -30,7 +30,8 @@ export class AddMatchModalComponent implements OnInit {
   @Input() players: IPlayer[] = [];
   @Input() player1: IPlayer | null = null;
   @Input() player2: IPlayer | null = null;
-  
+  @Input() isAlreadySelected: boolean = false;
+
   errorsOfSets: string[] = [];
   errorsOfPoints: string[] = [];
 

--- a/src/app/components/add-match-modal/add-match-modal.component.ts
+++ b/src/app/components/add-match-modal/add-match-modal.component.ts
@@ -13,6 +13,7 @@ import { LoaderService } from '../../../services/loader.service';
 import { TranslationService } from '../../../services/translation.service';
 import { CompetitionService } from '../../../services/competitions.service';
 import { ICompetition } from '../../../api/competition.api';
+import { IPlayer } from '../../../services/players.service';
 
 @Component({
   selector: 'app-add-match-modal',
@@ -25,8 +26,11 @@ export class AddMatchModalComponent implements OnInit {
 
   @Output() closeModalEvent = new EventEmitter<void>();
   @Output() openManualPointsEvent = new EventEmitter<void>();
-  @Input() players: any[] = [];
 
+  @Input() players: IPlayer[] = [];
+  @Input() player1: IPlayer | null = null;
+  @Input() player2: IPlayer | null = null;
+  
   errorsOfSets: string[] = [];
   errorsOfPoints: string[] = [];
 
@@ -67,8 +71,8 @@ export class AddMatchModalComponent implements OnInit {
   initializeForm() {
     this.matchForm = this.fb.group({
       date: [new Date().toISOString().split('T')[0], Validators.required],
-      player1: ['', Validators.required],
-      player2: ['', Validators.required],
+      player1: [this.player1?.id, Validators.required],
+      player2: [this.player2?.id, Validators.required],
       p1Score: [null, [Validators.required, Validators.min(1), Validators.max(this.maxSets)]],
       p2Score: [null, [Validators.required, Validators.min(1), Validators.max(this.maxSets)]],
       isShowSetsPointsTrue: [false],
@@ -76,6 +80,9 @@ export class AddMatchModalComponent implements OnInit {
     });
     this.matchForm.get('p1Score')?.valueChanges.subscribe(() => this.sanitizeInput('p1Score'));
     this.matchForm.get('p2Score')?.valueChanges.subscribe(() => this.sanitizeInput('p2Score'));
+    console.log('Initial form value:', this.matchForm.value);
+    console.log('Initial player 1:', this.player1);
+    console.log('Initial player 2:', this.player2);
   }
 
   get setsPoints(): FormArray {

--- a/src/app/components/add-match-modal/manual-points/manual-points.component.html
+++ b/src/app/components/add-match-modal/manual-points/manual-points.component.html
@@ -50,7 +50,7 @@
             <div class="row align-items-center justify-content-center">
                 <!-- Player 1 -->
                 <div class="col-12 col-md-5 mb-3 mb-md-0">
-                    <app-select-player [players]="getPlayers(1)" [playerNumber]="'1'"
+                    <app-select-player [players]="getPlayers(1)" [playerNumber]="'1'" [initialPlayer]="player1"
                         (playerSelected)="setPlayer($event)">
                     </app-select-player>
                 </div>
@@ -62,7 +62,7 @@
 
                 <!-- Player 2 -->
                 <div class="col-12 col-md-5">
-                    <app-select-player [players]="getPlayers(2)" [playerNumber]="'2'"
+                    <app-select-player [players]="getPlayers(2)" [playerNumber]="'2'" [initialPlayer]="player2"
                         (playerSelected)="setPlayer($event)">
                     </app-select-player>
                 </div>

--- a/src/app/components/add-match-modal/manual-points/manual-points.component.ts
+++ b/src/app/components/add-match-modal/manual-points/manual-points.component.ts
@@ -44,7 +44,7 @@ export class ManualPointsComponent {
   initialMaxPoints = 21;
   @Input() player2: IPlayer | null = null;
   @Input() player1: IPlayer | null = null;
-  @Input() players: any[] = [];
+  @Input() players: IPlayer[] = [];
 
   playersForm!: FormGroup;
 
@@ -64,6 +64,12 @@ export class ManualPointsComponent {
   ngOnChanges() {
     console.info('player1 value:', this.player1);
     console.info('player2 value:', this.player2);
+    if(this.playersForm) {
+      this.playersForm.patchValue({
+        player1: this.player1 || null,
+        player2: this.player2 || null
+      });
+    }
   }
 
 
@@ -76,8 +82,8 @@ export class ManualPointsComponent {
       this.maxSets = this.competition?.['sets_type'] || 10;
     });
     this.playersForm = this.fb.group({
-      player1: [null, Validators.required],
-      player2: [null, Validators.required]
+      player1: [this.player1?.id, Validators.required],
+      player2: [this.player2?.id, Validators.required]
     });
     this.playersForm.valueChanges.subscribe((val) => {
       this.player1 = this.players.find(p => p.id === val.player1) || null;

--- a/src/app/components/add-match-modal/manual-points/manual-points.component.ts
+++ b/src/app/components/add-match-modal/manual-points/manual-points.component.ts
@@ -22,22 +22,7 @@ export class ManualPointsComponent {
   @Output() close = new EventEmitter<any>();
   @ViewChild('effectLeft') effectLeft!: ElementRef;
   @ViewChild('effectRight') effectRight!: ElementRef;
-
-  onScoreChanged(event: { p1: number; p2: number }) {
-    // Clamp points to maxPoints
-    event.p1 = Math.min(event.p1, this.maxPoints + 1); // +1 per permettere il vantaggio
-    event.p2 = Math.min(event.p2, this.maxPoints + 1); // +1 per permettere il vantaggio
-    if (this.effectLeft && this.effectLeft.nativeElement) {
-      if (this.player1Points != event.p1) {
-        this.triggerHighlight(this.effectLeft);
-      }
-      if (this.player2Points != event.p2) {
-        this.triggerHighlight(this.effectRight);
-      }
-    }
-    this.player1Points = event.p1;
-    this.player2Points = event.p2;
-  }
+  @Input() isAlreadySelected: boolean = false;
 
   @Input() maxSets = 5;
   @Input() maxPoints = 21;
@@ -64,7 +49,7 @@ export class ManualPointsComponent {
   ngOnChanges() {
     console.info('player1 value:', this.player1);
     console.info('player2 value:', this.player2);
-    if(this.playersForm) {
+    if (this.playersForm) {
       this.playersForm.patchValue({
         player1: this.player1 || null,
         player2: this.player2 || null
@@ -90,6 +75,10 @@ export class ManualPointsComponent {
       this.player2 = this.players.find(p => p.id === val.player2) || null;
       console.log(val, this.player1, this.player2);
     });
+    
+    if (this.isAlreadySelected && this.player1 && this.player2) {
+      this.selectingPlayer = false;
+    }
   }
 
   @HostListener('window:resize')
@@ -99,6 +88,22 @@ export class ManualPointsComponent {
 
   private checkViewport() {
     this.isMobile = window.innerWidth <= 768 || window.innerWidth < window.innerHeight; // breakpoint mobile
+  }
+
+  onScoreChanged(event: { p1: number; p2: number }) {
+    // Clamp points to maxPoints
+    event.p1 = Math.min(event.p1, this.maxPoints + 1); // +1 per permettere il vantaggio
+    event.p2 = Math.min(event.p2, this.maxPoints + 1); // +1 per permettere il vantaggio
+    if (this.effectLeft && this.effectLeft.nativeElement) {
+      if (this.player1Points != event.p1) {
+        this.triggerHighlight(this.effectLeft);
+      }
+      if (this.player2Points != event.p2) {
+        this.triggerHighlight(this.effectRight);
+      }
+    }
+    this.player1Points = event.p1;
+    this.player2Points = event.p2;
   }
 
   changePoint(player: number) {
@@ -296,7 +301,7 @@ export class ManualPointsComponent {
       player2: this.player2.id,
       p1Score: this.player1SetsPoints,  // set vinti da player1
       p2Score: this.player2SetsPoints,  // set vinti da player2
-      setsPoints: setsData              
+      setsPoints: setsData
     };
 
     console.log('Saving manual match...', formData);

--- a/src/app/components/elimination-bracket/elimination-bracket.component.html
+++ b/src/app/components/elimination-bracket/elimination-bracket.component.html
@@ -31,6 +31,19 @@
               <span class="player waiting">{{ 'elimination_waiting_player' | translate }}</span>
             </ng-template>
           </div>
+
+          <div class="bracket-match-actions">
+            <button type="button" (click)="modalService.openModal(modalService.MODALS['ADD_MATCH'])" class="add-match">
+              {{ 'add_match' | translate }}
+              <span class="m-1"></span>
+              <i class="fa fa-file-text-o" aria-hidden="true"></i>
+            </button>
+            <button type="button" class="bg-secondary position-relative"
+              (click)="modalService.openModal(modalService.MODALS['MANUAL_POINTS'])">
+              {{ 'add_manual_set_points' | translate }}
+              <div class="circle-live"></div>
+            </button>
+          </div>
         </article>
       </div>
     </div>

--- a/src/app/components/elimination-bracket/elimination-bracket.component.html
+++ b/src/app/components/elimination-bracket/elimination-bracket.component.html
@@ -33,13 +33,14 @@
           </div>
 
           <div class="bracket-match-actions">
-            <button type="button" (click)="modalService.openModal(modalService.MODALS['ADD_MATCH'])" class="add-match">
+            <button type="button" 
+              (click)="openModal('ADD_MATCH', match.slots[0].player, match.slots[1].player)">
               {{ 'add_match' | translate }}
               <span class="m-1"></span>
               <i class="fa fa-file-text-o" aria-hidden="true"></i>
             </button>
             <button type="button" class="bg-secondary position-relative"
-              (click)="modalService.openModal(modalService.MODALS['MANUAL_POINTS'])">
+              (click)="openModal('MANUAL_POINTS', match.slots[0].player, match.slots[1].player)">
               {{ 'add_manual_set_points' | translate }}
               <div class="circle-live"></div>
             </button>

--- a/src/app/components/elimination-bracket/elimination-bracket.component.scss
+++ b/src/app/components/elimination-bracket/elimination-bracket.component.scss
@@ -98,7 +98,7 @@
 .bracket-match-actions {
   display: grid;
   gap: 0.5rem;
-
+  display: flex;
   button {
     min-height: 2.75rem;
     font-weight: 600;

--- a/src/app/components/elimination-bracket/elimination-bracket.component.scss
+++ b/src/app/components/elimination-bracket/elimination-bracket.component.scss
@@ -95,6 +95,17 @@
   border: 0.0625rem dashed rgba(255, 255, 255, 0.08);
 }
 
+.bracket-match-actions {
+  display: grid;
+  gap: 0.5rem;
+
+  button {
+    min-height: 2.75rem;
+    font-weight: 600;
+    font-size: 0.9rem;
+  }
+}
+
 .slot {
   display: flex;
   align-items: center;

--- a/src/app/components/elimination-bracket/elimination-bracket.component.ts
+++ b/src/app/components/elimination-bracket/elimination-bracket.component.ts
@@ -1,9 +1,10 @@
 import { CommonModule } from '@angular/common';
-import { Component, Input, inject } from '@angular/core';
+import { Component, Input, Output, EventEmitter, inject } from '@angular/core';
 import { ICompetition } from '../../../api/competition.api';
 import { TranslatePipe } from '../../utils/translate.pipe';
 import { EliminationRound } from '../../interfaces/elimination-bracket.interface';
 import { ModalService } from '../../../services/modal.service';
+import { IPlayer } from '../../../services/players.service';
 
 @Component({
   selector: 'app-elimination-bracket',
@@ -16,6 +17,7 @@ export class EliminationBracketComponent {
   @Input() competition: ICompetition | null = null;
   @Input() rounds: EliminationRound[] = [];
   modalService = inject(ModalService);
+  @Output() playersSelected = new EventEmitter<{ modalName: string, player1: IPlayer | null, player2: IPlayer | null }>();
 
   ngOnInit() {
     console.log('EliminationBracketComponent initialized');
@@ -24,12 +26,15 @@ export class EliminationBracketComponent {
   }
 
   trackByRound(index: number, round: EliminationRound) {
-    console.log('trackByRound called:', index, round);
     return `${round.name}-${index}`;
   }
 
   trackByMatch(index: number, _match: unknown) {
-    console.log('trackByMatch called:', index, _match);
     return index;
+  }
+  openModal(modalName: string, player1: any, player2: any) {
+    console.log('openModal called with:', modalName, player1, player2);
+    const objectToEmit = { modalName, player1, player2 };
+    this.playersSelected.emit(objectToEmit);
   }
 }

--- a/src/app/components/elimination-bracket/elimination-bracket.component.ts
+++ b/src/app/components/elimination-bracket/elimination-bracket.component.ts
@@ -1,8 +1,9 @@
 import { CommonModule } from '@angular/common';
-import { Component, Input } from '@angular/core';
+import { Component, Input, inject } from '@angular/core';
 import { ICompetition } from '../../../api/competition.api';
 import { TranslatePipe } from '../../utils/translate.pipe';
 import { EliminationRound } from '../../interfaces/elimination-bracket.interface';
+import { ModalService } from '../../../services/modal.service';
 
 @Component({
   selector: 'app-elimination-bracket',
@@ -14,6 +15,7 @@ import { EliminationRound } from '../../interfaces/elimination-bracket.interface
 export class EliminationBracketComponent {
   @Input() competition: ICompetition | null = null;
   @Input() rounds: EliminationRound[] = [];
+  modalService = inject(ModalService);
 
   ngOnInit() {
     console.log('EliminationBracketComponent initialized');

--- a/src/app/components/home.component.html
+++ b/src/app/components/home.component.html
@@ -1,7 +1,8 @@
 <ng-container *ngIf="userState$ | async as state">
     <div class="wrapper" *ngIf="players.length >= 2">
         <ng-container *ngIf="isEliminationMode && activeCompetition; else leagueMode">
-            <app-elimination-bracket [competition]="activeCompetition" [rounds]="eliminationRounds"></app-elimination-bracket>
+            <app-elimination-bracket (playersSelected)="onClickRound($event)" [competition]="activeCompetition"
+                [rounds]="eliminationRounds"></app-elimination-bracket>
         </ng-container>
     </div>
     <ng-template #leagueMode>
@@ -26,7 +27,8 @@
                     </div>
                     <div class="button-container">
                         <div>
-                            <button type="button" class="bg-secondary position-relative" (click)="modalService.openModal(modalService.MODALS['MANUAL_POINTS'])">
+                            <button type="button" class="bg-secondary position-relative"
+                                (click)="modalService.openModal(modalService.MODALS['MANUAL_POINTS'])">
                                 {{ "add_manual_set_points" | translate }}
                                 <div class="circle-live"></div>
                             </button>
@@ -44,7 +46,8 @@
     </ng-template>
     <app-modal [label]="'add_match'" *ngIf="modalService.isActiveModal(modalService.MODALS['ADD_MATCH'])"
         [modalName]="modalService.MODALS['ADD_MATCH']">
-        <app-add-match-modal [players]="players"></app-add-match-modal>
+        <app-add-match-modal [players]="players" [player1]="player1Selected"
+            [player2]="player2Selected"></app-add-match-modal>
     </app-modal>
     <app-modal [label]="'match_details'" *ngIf="modalService.isActiveModal(modalService.MODALS['SHOW_MATCH'])"
         [modalName]="modalService.MODALS['SHOW_MATCH']">
@@ -53,8 +56,8 @@
     <app-bottom-navbar class="bottom-navbar"></app-bottom-navbar>
 </ng-container>
 
-<app-modal [fullscreen]="true" [label]="'manual_points'" *ngIf="modalService.isActiveModal(modalService.MODALS['MANUAL_POINTS'])"
-    [modalName]="modalService.MODALS['MANUAL_POINTS']"
-    class="manual-points-modal">
-    <app-manual-points [players]="players"></app-manual-points>
+<app-modal [fullscreen]="true" [label]="'manual_points'"
+    *ngIf="modalService.isActiveModal(modalService.MODALS['MANUAL_POINTS'])"
+    [modalName]="modalService.MODALS['MANUAL_POINTS']" class="manual-points-modal">
+    <app-manual-points [players]="players" [player1]="player1Selected" [player2]="player2Selected"></app-manual-points>
 </app-modal>

--- a/src/app/components/home.component.html
+++ b/src/app/components/home.component.html
@@ -44,20 +44,24 @@
             </section>
         </div>
     </ng-template>
-    <app-modal [label]="'add_match'" *ngIf="modalService.isActiveModal(modalService.MODALS['ADD_MATCH'])"
-        [modalName]="modalService.MODALS['ADD_MATCH']">
-        <app-add-match-modal [players]="players" [player1]="player1Selected"
-            [player2]="player2Selected"></app-add-match-modal>
-    </app-modal>
-    <app-modal [label]="'match_details'" *ngIf="modalService.isActiveModal(modalService.MODALS['SHOW_MATCH'])"
-        [modalName]="modalService.MODALS['SHOW_MATCH']">
-        <app-show-match-modal [match]="clickedMatch"></app-show-match-modal>
-    </app-modal>
+
     <app-bottom-navbar class="bottom-navbar"></app-bottom-navbar>
 </ng-container>
+
+<app-modal [label]="'add_match'" *ngIf="modalService.isActiveModal(modalService.MODALS['ADD_MATCH'])"
+    [modalName]="modalService.MODALS['ADD_MATCH']">
+    <add-match-modal [isAlreadySelected]="!!player1Selected && !!player2Selected" [players]="players"
+        [player1]="player1Selected" [player2]="player2Selected"></add-match-modal>
+</app-modal>
+
+<app-modal [label]="'match_details'" *ngIf="modalService.isActiveModal(modalService.MODALS['SHOW_MATCH'])"
+    [modalName]="modalService.MODALS['SHOW_MATCH']">
+    <app-show-match-modal [match]="clickedMatch"></app-show-match-modal>
+</app-modal>
 
 <app-modal [fullscreen]="true" [label]="'manual_points'"
     *ngIf="modalService.isActiveModal(modalService.MODALS['MANUAL_POINTS'])"
     [modalName]="modalService.MODALS['MANUAL_POINTS']" class="manual-points-modal">
-    <app-manual-points [players]="players" [player1]="player1Selected" [player2]="player2Selected"></app-manual-points>
+    <app-manual-points [isAlreadySelected]="!!player1Selected && !!player2Selected" [players]="players"
+        [player1]="player1Selected" [player2]="player2Selected"></app-manual-points>
 </app-modal>

--- a/src/app/components/home.component.ts
+++ b/src/app/components/home.component.ts
@@ -46,6 +46,9 @@ export class HomeComponent {
   isEliminationMode = false;
   eliminationRounds: EliminationRound[] = [];
 
+  player1Selected: IPlayer | null = null;
+  player2Selected: IPlayer | null = null;
+
   constructor(public modalService: ModalService, private loaderService: LoaderService, private translateService: TranslationService, private router: Router) { }
 
   ngOnInit() {
@@ -152,5 +155,10 @@ export class HomeComponent {
 
     return rounds;
   }
-
+  onClickRound(event: any) {
+    console.log(event);
+    this.player1Selected = event.player1;
+    this.player2Selected = event.player2;
+    this.modalService.openModal(this.modalService.MODALS[event.modalName]);
+  }
 }

--- a/src/app/utils/components/select-player/select-player.component.ts
+++ b/src/app/utils/components/select-player/select-player.component.ts
@@ -12,6 +12,7 @@ import {
 } from '@angular/core';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { TranslatePipe } from '../../translate.pipe';
+import { IPlayer } from '../../../../services/players.service';
 
 @Component({
   selector: 'app-select-player',
@@ -21,8 +22,9 @@ import { TranslatePipe } from '../../translate.pipe';
   styleUrls: ['./select-player.component.scss'],
 })
 export class SelectPlayerComponent implements OnInit, OnChanges {
-  @Input() players: { id?: number; nickname: string }[] = [];
+  @Input() players: IPlayer[] = [];
   @Input() playerNumber: string = '';
+  @Input() initialPlayer: IPlayer | null = null;
 
   @Output() playerSelected = new EventEmitter<any>();
 
@@ -44,6 +46,10 @@ export class SelectPlayerComponent implements OnInit, OnChanges {
   ngOnChanges(changes: SimpleChanges) {
     if (changes['players'] && this.players) {
       this.filteredPlayers = [...this.players];
+    }
+
+    if (changes['players'] || changes['initialPlayer']) {
+      this.setSelectedPlayer();
     }
   }
 
@@ -77,5 +83,19 @@ export class SelectPlayerComponent implements OnInit, OnChanges {
     player.playerNumber = this.playerNumber;
     this.playerSelected.emit(player);
     this.closeDropdown();
+  }
+
+  private setSelectedPlayer() {
+    if (this.initialPlayer?.id) {
+      const matchedPlayer = this.players.find(
+        (player) => player.id === this.initialPlayer?.id
+      );
+      if (matchedPlayer) {
+        this.selectedPlayer = matchedPlayer;
+        return;
+      }
+    }
+
+    this.selectedPlayer = null;
   }
 }


### PR DESCRIPTION
## Summary
- add match management buttons to each elimination bracket match that open the existing add match and manual points modals
- inject the shared modal service into the elimination bracket component to reuse home modal handling
- style the new action buttons within bracket matches for consistent layout

## Testing
- npm run lint *(fails: Missing script: "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68d129f11dd08322b01e09da3469434c