### PR TITLE
Sync select player component with form selections

### DIFF
--- a/src/app/components/add-match-modal/add-match-modal.component.html
+++ b/src/app/components/add-match-modal/add-match-modal.component.html
@@ -10,11 +10,13 @@
         <!-- GIOCATORI -->
         <div class="row mt-3">
             <div class="col-md-6">
-                <app-select-player [players]="getPlayers(1)" [playerNumber]="'1'" (playerSelected)="setPlayer($event)">
+                <app-select-player [players]="getPlayers(1)" [playerNumber]="'1'"
+                    [selectedPlayerId]="matchForm.get('player1')?.value" (playerSelected)="setPlayer($event)">
                 </app-select-player>
             </div>
             <div class="col-md-6">
-                <app-select-player [players]="getPlayers(2)" [playerNumber]="'2'" (playerSelected)="setPlayer($event)">
+                <app-select-player [players]="getPlayers(2)" [playerNumber]="'2'"
+                    [selectedPlayerId]="matchForm.get('player2')?.value" (playerSelected)="setPlayer($event)">
                 </app-select-player>
             </div>
         </div>

--- a/src/app/components/add-match-modal/manual-points/manual-points.component.html
+++ b/src/app/components/add-match-modal/manual-points/manual-points.component.html
@@ -51,7 +51,7 @@
                 <!-- Player 1 -->
                 <div class="col-12 col-md-5 mb-3 mb-md-0">
                     <app-select-player [players]="getPlayers(1)" [playerNumber]="'1'"
-                        (playerSelected)="setPlayer($event)">
+                        [selectedPlayerId]="playersForm.get('player1')?.value" (playerSelected)="setPlayer($event)">
                     </app-select-player>
                 </div>
 
@@ -63,7 +63,7 @@
                 <!-- Player 2 -->
                 <div class="col-12 col-md-5">
                     <app-select-player [players]="getPlayers(2)" [playerNumber]="'2'"
-                        (playerSelected)="setPlayer($event)">
+                        [selectedPlayerId]="playersForm.get('player2')?.value" (playerSelected)="setPlayer($event)">
                     </app-select-player>
                 </div>
             </div>

--- a/src/app/utils/components/select-player/select-player.component.html
+++ b/src/app/utils/components/select-player/select-player.component.html
@@ -4,7 +4,10 @@
 
     <!-- Fake input field -->
     <div class="input-field position-relative" style="text-align: left;" (click)="toggleDropdown($event)" [class.open]="showDropdown">
-        <span *ngIf="!selectedPlayer" class="my-placeholder">
+        <span *ngIf="!selectedPlayer && players?.length === 0" class="my-placeholder">
+            {{"loading" | translate}}...
+        </span>
+        <span *ngIf="!selectedPlayer && players?.length > 0" class="my-placeholder">
             {{"Select a player" | translate}}...
         </span>
         <span *ngIf="selectedPlayer">

--- a/src/app/utils/components/select-player/select-player.component.ts
+++ b/src/app/utils/components/select-player/select-player.component.ts
@@ -23,6 +23,7 @@ import { TranslatePipe } from '../../translate.pipe';
 export class SelectPlayerComponent implements OnInit, OnChanges {
   @Input() players: { id?: number; nickname: string }[] = [];
   @Input() playerNumber: string = '';
+  @Input() selectedPlayerId: number | string | null = null;
 
   @Output() playerSelected = new EventEmitter<any>();
 
@@ -45,6 +46,34 @@ export class SelectPlayerComponent implements OnInit, OnChanges {
     if (changes['players'] && this.players) {
       this.filteredPlayers = [...this.players];
     }
+
+    if (changes['selectedPlayerId'] || changes['players']) {
+      this.updateSelectedPlayer();
+    }
+  }
+
+  private updateSelectedPlayer() {
+    const parsedId = this.parseSelectedPlayerId(this.selectedPlayerId);
+    if (parsedId === null) {
+      this.selectedPlayer = null;
+      return;
+    }
+
+    const matchedPlayer = this.players.find((player) => player.id === parsedId) || null;
+    this.selectedPlayer = matchedPlayer;
+  }
+
+  private parseSelectedPlayerId(value: number | string | null): number | null {
+    if (value === null || value === undefined || value === '') {
+      return null;
+    }
+
+    if (typeof value === 'number') {
+      return Number.isNaN(value) ? null : value;
+    }
+
+    const parsed = Number(value);
+    return Number.isNaN(parsed) ? null : parsed;
   }
 
   toggleDropdown(event: Event) {


### PR DESCRIPTION
## Summary
- add a selectedPlayerId input to the select-player component and sync the selected entry when inputs change
- show a loading placeholder when the players list is empty
- propagate selected player ids from the add match and manual points forms so preselected values display immediately

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68d170d8527083228096da6dc975d5b6