### PR TITLE
Prefill select player with initial selection

### DIFF
--- a/src/app/components/add-match-modal/add-match-modal.component.html
+++ b/src/app/components/add-match-modal/add-match-modal.component.html
@@ -10,11 +10,13 @@
         <!-- GIOCATORI -->
         <div class="row mt-3">
             <div class="col-md-6">
-                <app-select-player [players]="getPlayers(1)" [playerNumber]="'1'" (playerSelected)="setPlayer($event)">
+                <app-select-player [players]="getPlayers(1)" [playerNumber]="'1'" [initialPlayer]="player1"
+                    (playerSelected)="setPlayer($event)">
                 </app-select-player>
             </div>
             <div class="col-md-6">
-                <app-select-player [players]="getPlayers(2)" [playerNumber]="'2'" (playerSelected)="setPlayer($event)">
+                <app-select-player [players]="getPlayers(2)" [playerNumber]="'2'" [initialPlayer]="player2"
+                    (playerSelected)="setPlayer($event)">
                 </app-select-player>
             </div>
         </div>

--- a/src/app/components/add-match-modal/manual-points/manual-points.component.html
+++ b/src/app/components/add-match-modal/manual-points/manual-points.component.html
@@ -50,7 +50,7 @@
             <div class="row align-items-center justify-content-center">
                 <!-- Player 1 -->
                 <div class="col-12 col-md-5 mb-3 mb-md-0">
-                    <app-select-player [players]="getPlayers(1)" [playerNumber]="'1'"
+                    <app-select-player [players]="getPlayers(1)" [playerNumber]="'1'" [initialPlayer]="player1"
                         (playerSelected)="setPlayer($event)">
                     </app-select-player>
                 </div>
@@ -62,7 +62,7 @@
 
                 <!-- Player 2 -->
                 <div class="col-12 col-md-5">
-                    <app-select-player [players]="getPlayers(2)" [playerNumber]="'2'"
+                    <app-select-player [players]="getPlayers(2)" [playerNumber]="'2'" [initialPlayer]="player2"
                         (playerSelected)="setPlayer($event)">
                     </app-select-player>
                 </div>

--- a/src/app/utils/components/select-player/select-player.component.ts
+++ b/src/app/utils/components/select-player/select-player.component.ts
@@ -12,6 +12,7 @@ import {
 } from '@angular/core';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { TranslatePipe } from '../../translate.pipe';
+import { IPlayer } from '../../../../services/players.service';
 
 @Component({
   selector: 'app-select-player',
@@ -21,8 +22,9 @@ import { TranslatePipe } from '../../translate.pipe';
   styleUrls: ['./select-player.component.scss'],
 })
 export class SelectPlayerComponent implements OnInit, OnChanges {
-  @Input() players: { id?: number; nickname: string }[] = [];
+  @Input() players: IPlayer[] = [];
   @Input() playerNumber: string = '';
+  @Input() initialPlayer: IPlayer | null = null;
 
   @Output() playerSelected = new EventEmitter<any>();
 
@@ -44,6 +46,10 @@ export class SelectPlayerComponent implements OnInit, OnChanges {
   ngOnChanges(changes: SimpleChanges) {
     if (changes['players'] && this.players) {
       this.filteredPlayers = [...this.players];
+    }
+
+    if (changes['players'] || changes['initialPlayer']) {
+      this.setSelectedPlayer();
     }
   }
 
@@ -77,5 +83,19 @@ export class SelectPlayerComponent implements OnInit, OnChanges {
     player.playerNumber = this.playerNumber;
     this.playerSelected.emit(player);
     this.closeDropdown();
+  }
+
+  private setSelectedPlayer() {
+    if (this.initialPlayer?.id) {
+      const matchedPlayer = this.players.find(
+        (player) => player.id === this.initialPlayer?.id
+      );
+      if (matchedPlayer) {
+        this.selectedPlayer = matchedPlayer;
+        return;
+      }
+    }
+
+    this.selectedPlayer = null;
   }
 }


### PR DESCRIPTION
## Summary
- add support for pre-selecting a player in SelectPlayerComponent via a new `initialPlayer` input
- ensure the select widget displays the provided player when players or the initial selection change
- pass the current turn players into the select component in the add match and manual points modals

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1bd6f50d88322b6013120bc32ee51