### PR TITLE
Add score display to elimination bracket slots

### DIFF
--- a/src/app/components/elimination-bracket/elimination-bracket.component.html
+++ b/src/app/components/elimination-bracket/elimination-bracket.component.html
@@ -24,9 +24,10 @@
           <div class="slot" *ngFor="let slot of match.slots">
             <span class="seed">#{{ slot.seed }}</span>
             <img class="avatar" src="{{ slot.player?.image_url || 'default-player.jpg' }}" alt="">
-            <span class="player" *ngIf="slot.player; else waiting">
-              {{ slot.player.nickname || slot.player.name }}
-            </span>
+            <div class="player" *ngIf="slot.player; else waiting">
+              <span class="player-name">{{ slot.player.nickname || slot.player.name }}</span>
+              <span class="player-score" *ngIf="slot.score !== undefined && slot.score !== null">{{ slot.score }}</span>
+            </div>
             <ng-template #waiting>
               <span class="player waiting">{{ 'elimination_waiting_player' | translate }}</span>
             </ng-template>

--- a/src/app/components/elimination-bracket/elimination-bracket.component.scss
+++ b/src/app/components/elimination-bracket/elimination-bracket.component.scss
@@ -122,15 +122,32 @@
 }
 
 .player {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  justify-content: space-between;
+  flex: 1;
   font-size: 1rem;
   font-weight: 600;
   text-align: right;
 
   &.waiting {
+    display: inline-block;
     font-style: italic;
     font-weight: 400;
     opacity: 0.65;
   }
+}
+
+.player-name {
+  flex: 1;
+}
+
+.player-score {
+  min-width: 2rem;
+  text-align: center;
+  font-weight: 700;
+  font-size: 1rem;
 }
 
 .elimination-footer {

--- a/src/app/interfaces/elimination-bracket.interface.ts
+++ b/src/app/interfaces/elimination-bracket.interface.ts
@@ -3,6 +3,7 @@ import { IPlayer } from '../../services/players.service';
 export interface EliminationMatchSlot {
   seed: number;
   player: IPlayer | null;
+  score?: number | null;
 }
 
 export interface EliminationMatch {


### PR DESCRIPTION
## Summary
- allow elimination bracket slots to surface optional player scores
- adjust bracket markup to pair player names with associated scores when available
- update styling so player rows flexibly align names and score values

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1bf3af4fc8322a5673a3eec3c65e5