### PR TITLE
Display match scores in elimination bracket

### DIFF
--- a/src/app/components/elimination-bracket/elimination-bracket.component.html
+++ b/src/app/components/elimination-bracket/elimination-bracket.component.html
@@ -21,11 +21,17 @@
       <h3>{{ round.name | translate }}</h3>
       <div class="bracket-matches">
         <article class="bracket-match" *ngFor="let match of round.matches; trackBy: trackByMatch">
-          <div class="slot" *ngFor="let slot of match.slots">
+          <div class="slot"
+            *ngFor="let slot of match.slots; let slotIndex = index"
+            [class.winner]="isSlotWinner(slot, match.winnerId)">
             <span class="seed">#{{ slot.seed }}</span>
             <img class="avatar" src="{{ slot.player?.image_url || 'default-player.jpg' }}" alt="">
             <span class="player" *ngIf="slot.player; else waiting">
               {{ slot.player.nickname || slot.player.name }}
+            </span>
+            <span class="score"
+              *ngIf="slot.player && (slotIndex === 0 ? match.player1Score !== undefined && match.player1Score !== null : match.player2Score !== undefined && match.player2Score !== null)">
+              {{ slotIndex === 0 ? match.player1Score : match.player2Score }}
             </span>
             <ng-template #waiting>
               <span class="player waiting">{{ 'elimination_waiting_player' | translate }}</span>

--- a/src/app/components/elimination-bracket/elimination-bracket.component.scss
+++ b/src/app/components/elimination-bracket/elimination-bracket.component.scss
@@ -126,6 +126,17 @@
   padding: 0.5rem 0.75rem;
   border-radius: 0.5rem;
   background: rgba(15, 23, 42, 0.25);
+
+  &.winner {
+    border: 0.0625rem solid rgba(255, 255, 255, 0.25);
+    background: rgba(15, 23, 42, 0.45);
+  }
+
+  .score {
+    margin-left: auto;
+    font-weight: 700;
+    font-size: 1rem;
+  }
 }
 
 .seed {

--- a/src/app/components/elimination-bracket/elimination-bracket.component.ts
+++ b/src/app/components/elimination-bracket/elimination-bracket.component.ts
@@ -2,7 +2,7 @@ import { CommonModule } from '@angular/common';
 import { Component, Input, Output, EventEmitter, inject } from '@angular/core';
 import { ICompetition } from '../../../api/competition.api';
 import { TranslatePipe } from '../../utils/translate.pipe';
-import { EliminationRound } from '../../interfaces/elimination-bracket.interface';
+import { EliminationMatchSlot, EliminationRound } from '../../interfaces/elimination-bracket.interface';
 import { ModalService } from '../../../services/modal.service';
 import { IPlayer } from '../../../services/players.service';
 
@@ -36,6 +36,14 @@ export class EliminationBracketComponent {
     console.log('openModal called with:', modalName, player1, player2);
     const objectToEmit = { modalName, player1, player2 };
     this.playersSelected.emit(objectToEmit);
+  }
+
+  isSlotWinner(slot: EliminationMatchSlot, winnerId: number | string | null | undefined): boolean {
+    if (!slot?.player || winnerId == null) {
+      return false;
+    }
+
+    return String(slot.player.id) === String(winnerId);
   }
 
 }

--- a/src/app/components/home.component.html
+++ b/src/app/components/home.component.html
@@ -7,11 +7,11 @@
     </div>
     <ng-template #leagueMode>
         <div class="league-wrapper">
-            <p *ngIf="matches?.length === 0" class="mt-4 text-center">
+            <p *ngIf="matches.length === 0" class="mt-4 text-center">
                 {{ "matches_not_found" | translate }}
             </p>
             <section style="padding: 0;">
-                <app-matches *ngIf="matches?.length > 0" [matches]="matches" (matchEmitter)="setClickedMatch($event)">
+                <app-matches *ngIf="matches.length > 0" [matches]="matches" (matchEmitter)="setClickedMatch($event)">
                 </app-matches>
                 <div class="buttons-home-matches">
                     <div class="button-container mt-3">
@@ -40,7 +40,7 @@
                 </div>
             </section>
             <section>
-                <app-stats *ngIf="matches?.length > 0"></app-stats>
+                <app-stats *ngIf="matches.length > 0"></app-stats>
             </section>
         </div>
     </ng-template>


### PR DESCRIPTION
## Summary
- include match results when building elimination rounds and update when matches load
- surface scores and winner styling for each bracket slot
- adjust league mode templates to use non-null match lists

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d25d0f591c83228c5c4dca1aab946e