### PR TITLE
feat: add group knockout hybrid component

### DIFF
--- a/public/lang.json
+++ b/public/lang.json
@@ -827,5 +827,22 @@
     "view_details": {
         "it": "Vedi dettagli",
         "en": "View details"
+    },
+    "are_you_sure": {
+        "it": "Sei sicuro?",
+        "en": "Are you sure?"
+    },
+
+    "are-you-sure-deleting": {
+        "it": "Sei sicuro di voler eliminare il giocatore?",
+        "en": "Are you sure you want to delete the player?"
+    },
+    "delete_player": {
+        "it": "Elimina giocatore",
+        "en": "Delete player"
+    },
+    "delete": {
+        "it": "Elimina",
+        "en": "Delete"
     }
 }

--- a/src/api/api.config.ts
+++ b/src/api/api.config.ts
@@ -14,7 +14,7 @@ export const API_PATHS = {
   addPlayers: '/api/add-players',
   deleteCompetition: '/api/delete-competition',
   updateActiveCompetition: '/api/update-active-competition',
-  deleteUserFromCompetition: '/api/delete-user-from-competition',
+  deletePlayer: '/api/delete-player',
 }
 
 export const API_AUTH_CONFIG: Record<string, { needsAuth: boolean; methods?: string[] }> = {
@@ -29,7 +29,7 @@ export const API_AUTH_CONFIG: Record<string, { needsAuth: boolean; methods?: str
   [API_PATHS.addPlayers]: { needsAuth: true, methods: ['POST'] },
   [API_PATHS.deleteCompetition]: { needsAuth: true, methods: ['DELETE'] },
   [API_PATHS.updateActiveCompetition]: { needsAuth: true, methods: ['POST'] },
-  [API_PATHS.deleteUserFromCompetition]: { needsAuth: true, methods: ['DELETE'] },
+  [API_PATHS.deletePlayer]: { needsAuth: true, methods: ['DELETE'] },
 };
 
 export function findApiConfig(url: string, method: string) {

--- a/src/api/competition.api.ts
+++ b/src/api/competition.api.ts
@@ -104,9 +104,9 @@ export class CompetitionApi {
     return this.http.post<any>(API_PATHS.updateActiveCompetition, { competitionId });
   }
 
-  deleteUserFromCompetition(competitionId: number | string, userId: number | string): Observable<any> {
-    return this.http.delete<any>(API_PATHS.deleteUserFromCompetition, {
-      body: { competitionId, userId },
+  deletePlayer(competitionId: number | string, playerId: number | string): Observable<any> {
+    return this.http.delete<any>(API_PATHS.deletePlayer, {
+      body: { competitionId, playerId },
     });
   }
 }

--- a/src/app/common/are-you-sure/are-you-sure.component.html
+++ b/src/app/common/are-you-sure/are-you-sure.component.html
@@ -1,0 +1,10 @@
+<div class="are-you-sure-modal">
+    <h2>{{ 'are_you_sure' | translate }}</h2>
+    <div>
+        <p class="mt-5">{{ body }}</p>
+        <div class="d-flex justify-content-between mt-5">
+            <button type="button" class="cancel contrast" (click)="cancelled.emit(true)">{{ 'cancel' | translate }}</button>
+            <button type="button" class="yes bg-secondary" (click)="confirmed.emit(true)">{{ 'delete' | translate }} <i class="fas fa-trash"></i></button>
+        </div>
+    </div>
+</div>

--- a/src/app/common/are-you-sure/are-you-sure.component.scss
+++ b/src/app/common/are-you-sure/are-you-sure.component.scss
@@ -1,0 +1,6 @@
+@use '../../../style/variables.scss' as *;
+
+.cancel {
+    background-color: $contrast!important;
+    color: black!important;
+}

--- a/src/app/common/are-you-sure/are-you-sure.component.spec.ts
+++ b/src/app/common/are-you-sure/are-you-sure.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AreYouSureComponent } from './are-you-sure.component';
+
+describe('AreYouSureComponent', () => {
+  let component: AreYouSureComponent;
+  let fixture: ComponentFixture<AreYouSureComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AreYouSureComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(AreYouSureComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/common/are-you-sure/are-you-sure.component.ts
+++ b/src/app/common/are-you-sure/are-you-sure.component.ts
@@ -1,0 +1,20 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { SHARED_IMPORTS } from '../imports/shared.imports';
+import { ModalComponent } from '../modal/modal.component';
+import { ModalService } from '../../../services/modal.service';
+
+@Component({
+  selector: 'are-you-sure',
+  imports: [SHARED_IMPORTS],
+  templateUrl: './are-you-sure.component.html',
+  styleUrl: './are-you-sure.component.scss'
+})
+
+export class AreYouSureComponent extends ModalComponent {
+  constructor(public override modalService: ModalService) {
+    super(modalService);
+  }
+  @Output() confirmed = new EventEmitter<boolean>();
+  @Output() cancelled = new EventEmitter<boolean>();
+  @Input() body: string = 'Are you sure you want to delete the player?';
+}

--- a/src/app/common/modal/modal.component.ts
+++ b/src/app/common/modal/modal.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, ElementRef, HostListener, Input, ViewChild } from '@angular/core';
+import { Component, ElementRef, EventEmitter, HostListener, Input, Output, ViewChild } from '@angular/core';
 import { ModalService } from '../../../services/modal.service';
 import { TranslatePipe } from '../../utils/translate.pipe';
 
@@ -17,6 +17,7 @@ export class ModalComponent {
   @Input() isSmall: boolean = false;
   @Input() fullscreen: boolean = false;
   @Input() transparent = false;
+  @Output() closeModalEvent = new EventEmitter<void>();
 
   constructor(public modalService: ModalService) { }
 
@@ -26,6 +27,7 @@ export class ModalComponent {
 
   closeModal(): void {
     this.modalService.closeModal();
+    this.closeModalEvent.emit();
   }
   toggleFullscreen(): void {
     this.fullscreen = !this.fullscreen;

--- a/src/app/components/competitions/add-competition-modal/add-competition-modal.component.ts
+++ b/src/app/components/competitions/add-competition-modal/add-competition-modal.component.ts
@@ -46,7 +46,6 @@ export class AddCompetitionModalComponent {
         icon: '/trophy.png',
         labelKey: 'competition_type_group_knockout',
         descriptionKey: 'competition_type_group_knockout_description',
-        disabled: true
       }
     ];
   }

--- a/src/app/components/competitions/competition-detail/competition-detail.component.html
+++ b/src/app/components/competitions/competition-detail/competition-detail.component.html
@@ -22,24 +22,27 @@
       <div>
         <h1>{{ competition?.name }}</h1>
       </div>
-      <button *ngIf="competition?.management !== 'admin'" class="invitation-code-container button flex-column" type="button" (click)="copyCode()">
+      <button *ngIf="competition?.management !== 'admin'" class="invitation-code-container button flex-column"
+        type="button" (click)="copyCode()">
         <div>{{"invitation_code" | translate}}: </div>
         <div class="value code">{{ competition?.['code'] }}</div>
       </button>
     </div>
     <div>
       <span>{{ "type" | translate }}: </span>
-      <span class="value competition-type">{{ ('competition_type_' + (competition?.type || 'league')) | translate }}</span>
+      <span class="value competition-type">{{ ('competition_type_' + (competition?.type || 'league')) | translate
+        }}</span>
       <i [ngClass]="['fa-solid', getCompetitionTypeIcon(competition?.type)]"></i>
     </div>
 
     <div class="players-container d-flex justify-content-between align-items-center">
       <div class="competition-players-container">
-        <div class="players" *ngFor="let p of competition?.['players']">
+        <button class="players" *ngFor="let p of competition?.['players']">
           <img *ngIf="p.image_url" class="avatar" [src]="p.image_url" />
           <img *ngIf="!p.image_url" class="avatar" [src]="'default-player.jpg'" />
           <span class="player-name">{{ p.nickname }}</span>
-        </div>
+          <button class="delete" (click)="openAreYouSureModal(p.id)"><i class="fa-solid fa-xmark"></i></button>
+        </button>
         <div *ngIf="isEmpty(competition?.['players'])">
           {{ "no_players" | translate }}
         </div>
@@ -48,7 +51,8 @@
     <div class="d-flex flex-column">
       <div>
         <div style="min-width: 9.375em">
-          <button class="button-primary-ping" id="add-players-button" (click)="modalService.openModal(modalService.MODALS['ADD_PLAYERS'])">
+          <button class="button-primary-ping" id="add-players-button"
+            (click)="modalService.openModal(modalService.MODALS['ADD_PLAYERS'])">
             {{ "add_players" | translate }}
             <i class="fa-solid fa-users ms-2"></i>
             <i class="fa-solid fa-plus"></i>
@@ -65,3 +69,9 @@
                                 { label: 'Delete', value: 'delete', icon: '<i class=\'fa-solid fa-trash\'></i>' }
                             ]" (actionSelected)="onDropdownAction($event)"></app-dropdown>
 </div>
+
+<app-modal [label]="'are_you_sure'" *ngIf="areYouSureVisible"
+  [modalName]="modalService.MODALS['ARE_YOU_SURE']"
+  (closeModalEvent)="areYouSureVisible = false">
+  <are-you-sure [body]="'are-you-sure-deleting' | translate" (confirmed)="onDeleteConfirmed()" (cancelled)="onDeleteCancelled()"></are-you-sure>
+</app-modal>

--- a/src/app/components/competitions/competition-detail/competition-detail.component.scss
+++ b/src/app/components/competitions/competition-detail/competition-detail.component.scss
@@ -108,6 +108,25 @@
   animation: highlight 2s ease-in-out 2;
 }
 
+.players {
+  all: unset;
+  cursor: pointer;
+  position: relative;
+
+  .delete {
+    position: absolute;
+    right: 0;
+    opacity: 0;
+  }
+
+  &:hover, &:focus-within {
+    .delete {
+      opacity: 1;
+    }
+  }
+
+}
+
 @keyframes highlight {
   0% {
     transform: scale(1);

--- a/src/app/components/competitions/competition-detail/competition-detail.component.ts
+++ b/src/app/components/competitions/competition-detail/competition-detail.component.ts
@@ -6,28 +6,35 @@ import { MSG_TYPE } from '../../../utils/enum';
 import { CompetitionService } from '../../../../services/competitions.service';
 import { LoaderService } from '../../../../services/loader.service';
 import { TranslationService } from '../../../../services/translation.service';
+import { ModalComponent } from '../../../common/modal/modal.component';
+import { AreYouSureComponent } from '../../../common/are-you-sure/are-you-sure.component';
+import { ElementRef, ViewChild } from '@angular/core';
 
 @Component({
   selector: 'app-competition-detail',
-  imports: [...SHARED_IMPORTS],
+  imports: [...SHARED_IMPORTS, ModalComponent, AreYouSureComponent],
   templateUrl: './competition-detail.component.html',
   styleUrl: './competition-detail.component.scss'
 })
 export class CompetitionDetailComponent {
 
   @Input() competition: ICompetition | null = null;
+  areYouSureVisible: boolean = false;
+  playerIdToDelete: number = -1;
+
+  @ViewChild('competitionDetail', { static: true }) competitionDetailRef!: ElementRef<HTMLElement>;
 
   ngOnChanges() {
     console.log('Competition input changed:', this.competition);
   }
   @Output() actionSelected = new EventEmitter<{ action: string, competition: ICompetition | null }>();
-  
+
   copied: boolean = false;
   private competitionService = inject(CompetitionService);
   activeCompetition$ = this.competitionService.activeCompetition$;
 
   constructor(public modalService: ModalService, private loader: LoaderService, private translateService: TranslationService) { }
-  
+
   readonly detailsModalName = 'viewCompetitionModal';
   readonly editModalName = 'editCompetitionModal';
 
@@ -90,5 +97,23 @@ export class CompetitionDetailComponent {
       default:
         return 'fa-users';
     }
+  }
+  deletePlayer(playerId: number) {
+    if (!this.competition?.id) {
+      return;
+    }
+    this.competitionService.removePlayerFromCompetition(this.competition.id, playerId).subscribe(() => {
+    });
+  }
+  openAreYouSureModal(playerId: number) {
+    this.playerIdToDelete = playerId;
+    this.areYouSureVisible = true;
+  }
+  onDeleteConfirmed() {
+    this.areYouSureVisible = false;
+    this.deletePlayer(this.playerIdToDelete);
+  }
+  onDeleteCancelled() {
+    this.areYouSureVisible = false;
   }
 }

--- a/src/app/components/group-knockout/group-knockout.component.html
+++ b/src/app/components/group-knockout/group-knockout.component.html
@@ -1,0 +1,42 @@
+<div class="group-knockout-wrapper">
+  <div class="league-wrapper">
+    <p *ngIf="matches.length === 0" class="mt-4 text-center">
+      {{ 'matches_not_found' | translate }}
+    </p>
+    <section style="padding: 0;">
+      <app-matches *ngIf="matches.length > 0" [matches]="matches" (matchEmitter)="onMatchSelected($event)">
+      </app-matches>
+      <div class="buttons-home-matches">
+        <div class="button-container mt-3">
+          <button type="button" (click)="modalService.openModal(modalService.MODALS['ADD_MATCH'])" class="add-match">
+            {{ 'add_match' | translate }}
+            <span class="m-1"></span>
+            <i class="fa fa-file-text-o" aria-hidden="true"></i>
+          </button>
+          <p class="small text-center mt-3">
+            {{ 'add_match_description' | translate }}
+          </p>
+        </div>
+        <div class="button-container">
+          <div>
+            <button type="button" class="bg-secondary position-relative"
+              (click)="modalService.openModal(modalService.MODALS['MANUAL_POINTS'])">
+              {{ 'add_manual_set_points' | translate }}
+              <div class="circle-live"></div>
+            </button>
+          </div>
+          <p class="small text-center mt-3">
+            {{ 'add_manual_set_points_description' | translate }}
+          </p>
+        </div>
+      </div>
+    </section>
+    <section>
+      <app-stats *ngIf="matches.length > 0"></app-stats>
+    </section>
+  </div>
+  <div class="wrapper" *ngIf="players.length >= 2">
+    <app-elimination-bracket [competition]="competition" [rounds]="rounds"
+      (playersSelected)="onRoundSelected($event)"></app-elimination-bracket>
+  </div>
+</div>

--- a/src/app/components/group-knockout/group-knockout.component.scss
+++ b/src/app/components/group-knockout/group-knockout.component.scss
@@ -1,0 +1,33 @@
+:host {
+  display: block;
+}
+
+.group-knockout-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5em;
+}
+
+.league-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5em;
+}
+
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5em;
+}
+
+.buttons-home-matches {
+  p {
+    color: rgb(141, 142, 142);
+  }
+}
+
+@media screen and (max-width: 62.5em) {
+  .wrapper {
+    margin-top: 4.6em;
+  }
+}

--- a/src/app/components/group-knockout/group-knockout.component.ts
+++ b/src/app/components/group-knockout/group-knockout.component.ts
@@ -1,0 +1,38 @@
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, Input, Output, inject } from '@angular/core';
+import { MatchesComponent } from '../matches/matches.component';
+import { StatsComponent } from '../../common/stats/stats.component';
+import { EliminationBracketComponent, EliminationModalEvent } from '../elimination-bracket/elimination-bracket.component';
+import { IMatch } from '../../interfaces/matchesInterfaces';
+import { EliminationRound } from '../../interfaces/elimination-bracket.interface';
+import { IPlayer } from '../../../services/players.service';
+import { ICompetition } from '../../../api/competition.api';
+import { TranslatePipe } from '../../utils/translate.pipe';
+import { ModalService } from '../../../services/modal.service';
+
+@Component({
+  selector: 'app-group-knockout',
+  standalone: true,
+  imports: [CommonModule, MatchesComponent, StatsComponent, EliminationBracketComponent, TranslatePipe],
+  templateUrl: './group-knockout.component.html',
+  styleUrl: './group-knockout.component.scss'
+})
+export class GroupKnockoutComponent {
+  @Input() matches: IMatch[] = [];
+  @Input() rounds: EliminationRound[] = [];
+  @Input() players: IPlayer[] = [];
+  @Input() competition: ICompetition | null = null;
+
+  @Output() matchSelected = new EventEmitter<IMatch>();
+  @Output() roundSelected = new EventEmitter<EliminationModalEvent>();
+
+  modalService = inject(ModalService);
+
+  onMatchSelected(match: IMatch) {
+    this.matchSelected.emit(match);
+  }
+
+  onRoundSelected(event: EliminationModalEvent) {
+    this.roundSelected.emit(event);
+  }
+}

--- a/src/app/components/home.component.html
+++ b/src/app/components/home.component.html
@@ -1,49 +1,55 @@
 <ng-container *ngIf="userState$ | async as state">
-    <div class="wrapper" *ngIf="players.length >= 2">
-        <ng-container *ngIf="isEliminationMode && activeCompetition; else leagueMode">
-            <app-elimination-bracket (playersSelected)="onClickRound($event)" [competition]="activeCompetition"
-                [rounds]="eliminationRounds"></app-elimination-bracket>
+    <ng-container [ngSwitch]="activeCompetition?.type">
+        <ng-container *ngSwitchCase="'elimination'">
+            <div class="wrapper" *ngIf="players.length >= 2 && activeCompetition">
+                <app-elimination-bracket (playersSelected)="onClickRound($event)"
+                    [competition]="activeCompetition" [rounds]="eliminationRounds"></app-elimination-bracket>
+            </div>
         </ng-container>
-    </div>
-    <ng-template #leagueMode>
-        <div class="league-wrapper">
-            <p *ngIf="matches.length === 0" class="mt-4 text-center">
-                {{ "matches_not_found" | translate }}
-            </p>
-            <section style="padding: 0;">
-                <app-matches *ngIf="matches.length > 0" [matches]="matches" (matchEmitter)="setClickedMatch($event)">
-                </app-matches>
-                <div class="buttons-home-matches">
-                    <div class="button-container mt-3">
-                        <button type="button" (click)="modalService.openModal(modalService.MODALS['ADD_MATCH'])"
-                            class="add-match">
-                            {{ "add_match" | translate}}
-                            <span class="m-1"></span>
-                            <i class="fa fa-file-text-o" aria-hidden="true"></i>
-                        </button>
-                        <p class="small text-center mt-3">
-                            {{ "add_match_description" | translate }}
-                        </p>
-                    </div>
-                    <div class="button-container">
-                        <div>
-                            <button type="button" class="bg-secondary position-relative"
-                                (click)="modalService.openModal(modalService.MODALS['MANUAL_POINTS'])">
-                                {{ "add_manual_set_points" | translate }}
-                                <div class="circle-live"></div>
+        <app-group-knockout *ngSwitchCase="'group_knockout'" [competition]="activeCompetition"
+            [matches]="matches" [players]="players" [rounds]="eliminationRounds"
+            (matchSelected)="setClickedMatch($event)" (roundSelected)="onClickRound($event)"></app-group-knockout>
+        <ng-container *ngSwitchDefault>
+            <div class="league-wrapper">
+                <p *ngIf="matches.length === 0" class="mt-4 text-center">
+                    {{ "matches_not_found" | translate }}
+                </p>
+                <section style="padding: 0;">
+                    <app-matches *ngIf="matches.length > 0" [matches]="matches"
+                        (matchEmitter)="setClickedMatch($event)">
+                    </app-matches>
+                    <div class="buttons-home-matches">
+                        <div class="button-container mt-3">
+                            <button type="button" (click)="modalService.openModal(modalService.MODALS['ADD_MATCH'])"
+                                class="add-match">
+                                {{ "add_match" | translate}}
+                                <span class="m-1"></span>
+                                <i class="fa fa-file-text-o" aria-hidden="true"></i>
                             </button>
+                            <p class="small text-center mt-3">
+                                {{ "add_match_description" | translate }}
+                            </p>
                         </div>
-                        <p class="small text-center mt-3">
-                            {{ "add_manual_set_points_description" | translate }}
-                        </p>
+                        <div class="button-container">
+                            <div>
+                                <button type="button" class="bg-secondary position-relative"
+                                    (click)="modalService.openModal(modalService.MODALS['MANUAL_POINTS'])">
+                                    {{ "add_manual_set_points" | translate }}
+                                    <div class="circle-live"></div>
+                                </button>
+                            </div>
+                            <p class="small text-center mt-3">
+                                {{ "add_manual_set_points_description" | translate }}
+                            </p>
+                        </div>
                     </div>
-                </div>
-            </section>
-            <section>
-                <app-stats *ngIf="matches.length > 0"></app-stats>
-            </section>
-        </div>
-    </ng-template>
+                </section>
+                <section>
+                    <app-stats *ngIf="matches.length > 0"></app-stats>
+                </section>
+            </div>
+        </ng-container>
+    </ng-container>
 
     <app-bottom-navbar class="bottom-navbar"></app-bottom-navbar>
 </ng-container>

--- a/src/app/components/home.component.ts
+++ b/src/app/components/home.component.ts
@@ -23,6 +23,7 @@ import { EliminationBracketComponent, EliminationModalEvent } from './eliminatio
 import { EliminationRound } from '../interfaces/elimination-bracket.interface';
 import { ICompetition } from '../../api/competition.api';
 import { Router } from '@angular/router';
+import { GroupKnockoutComponent } from './group-knockout/group-knockout.component';
 
 type MatchWithContext = IMatch & {
   competitionType?: CompetitionMode;
@@ -33,7 +34,7 @@ type MatchWithContext = IMatch & {
 
 @Component({
   selector: 'app-home',
-  imports: [CommonModule, BottomNavbarComponent, MatchesComponent, AddMatchModalComponent, ModalComponent, ShowMatchModalComponent, TranslatePipe, StatsComponent, ManualPointsComponent, EliminationBracketComponent],
+  imports: [CommonModule, BottomNavbarComponent, MatchesComponent, AddMatchModalComponent, ModalComponent, ShowMatchModalComponent, TranslatePipe, StatsComponent, ManualPointsComponent, EliminationBracketComponent, GroupKnockoutComponent],
   templateUrl: './home.component.html',
   styleUrl: './home.component.scss'
 })
@@ -51,6 +52,7 @@ export class HomeComponent {
   players: IPlayer[] = [];
   activeCompetition: ICompetition | null = null;
   isEliminationMode = false;
+  isGroupKnockoutMode = false;
   eliminationRounds: EliminationRound[] = [];
 
   player1Selected: IPlayer | null = null;
@@ -72,6 +74,7 @@ export class HomeComponent {
           }
           this.activeCompetition = activeCompetition ?? null;
           this.isEliminationMode = (activeCompetition?.type === 'elimination');
+          this.isGroupKnockoutMode = (activeCompetition?.type === 'group_knockout');
           this.updateEliminationRounds();
         });
       }
@@ -97,9 +100,10 @@ export class HomeComponent {
   }
 
   setClickedMatch(match: IMatch) {
+    const competitionType = (this.activeCompetition?.type ?? 'league') as CompetitionMode;
     this.clickedMatch = {
       ...match,
-      competitionType: 'league',
+      competitionType,
       competitionName: this.activeCompetition?.name ?? undefined,
       roundName: match.roundName ?? null,
       roundLabel: match.roundLabel ?? undefined,
@@ -107,7 +111,8 @@ export class HomeComponent {
   }
 
   private updateEliminationRounds() {
-    if (!this.isEliminationMode) {
+    const shouldBuildBracket = this.isEliminationMode || this.isGroupKnockoutMode;
+    if (!shouldBuildBracket) {
       this.eliminationRounds = [];
       return;
     }

--- a/src/app/interfaces/matchesInterfaces.ts
+++ b/src/app/interfaces/matchesInterfaces.ts
@@ -5,7 +5,7 @@ export interface IMatchSet {
   player2_score: number;
 }
 
-export type CompetitionMode = 'league' | 'elimination';
+export type CompetitionMode = 'league' | 'elimination' | 'group_knockout';
 
 export interface IMatch {
   id: string;

--- a/src/app/utils/components/select-player/select-player.component.html
+++ b/src/app/utils/components/select-player/select-player.component.html
@@ -5,7 +5,7 @@
     <!-- Fake input field -->
     <div #playerSelectRef class="input-field position-relative" style="text-align: left;" (click)="toggleDropdown($event)" [class.open]="showDropdown">
         <span *ngIf="!selectedPlayer" class="my-placeholder">
-            {{"Select a player" | translate}}...
+            {{"select_player" | translate}}...
         </span>
         <span *ngIf="selectedPlayer">
             <strong>{{ selectedPlayer.nickname }}</strong>

--- a/src/app/utils/components/select-player/select-player.component.ts
+++ b/src/app/utils/components/select-player/select-player.component.ts
@@ -106,7 +106,5 @@ export class SelectPlayerComponent implements OnInit, OnChanges {
         return;
       }
     }
-
-    this.selectedPlayer = null;
   }
 }

--- a/src/app/utils/enum.ts
+++ b/src/app/utils/enum.ts
@@ -61,6 +61,7 @@ export const MODALS: { [key: string]: string } = {
   MANUAL_POINTS: 'manualPointsModal',
   EDIT_COMPETITION: 'editCompetitionModal',
   VIEW_COMPETITION: 'viewCompetitionModal',
+  ARE_YOU_SURE: 'areYouSureModal',
 };
 
 export enum UserProgressStateEnum {

--- a/src/debug-overlay/debug-overlay.component.html
+++ b/src/debug-overlay/debug-overlay.component.html
@@ -1,4 +1,4 @@
-<div class="debug-overlay">
+<div class="debug-overlay" *ngIf="isDebugMode">
     <ng-container *ngIf="!isVisible">
         <button (click)="open()">Open debugger</button>
     </ng-container>

--- a/src/debug-overlay/debug-overlay.component.ts
+++ b/src/debug-overlay/debug-overlay.component.ts
@@ -18,7 +18,7 @@ export class DebugOverlayComponent {
   private comp = inject(CompetitionService);
   private user = inject(UserService);
   private auth = inject(AuthService, { optional: true });
-
+  isDebugMode = !environment.production;
   // stream principali
   list$ = this.comp.list$;
   active$ = this.comp.activeCompetition$;

--- a/src/services/competitions.service.ts
+++ b/src/services/competitions.service.ts
@@ -153,8 +153,8 @@ export class CompetitionService {
     );
   }
 
-  deleteUserFromCompetition(competitionId: number | string, userId: number | string): Observable<void> {
-    return this.api.deleteUserFromCompetition(competitionId, userId).pipe(
+  deletePlayer(competitionId: number | string, userId: number | string): Observable<void> {
+    return this.api.deletePlayer(competitionId, userId).pipe(
       tap(() => {
         const competition = this.store.snapshotById?.(competitionId);
         if (competition) {
@@ -165,7 +165,7 @@ export class CompetitionService {
       }),
       map(() => void 0),
       catchError(err => {
-        console.error('[CompetitionService] deleteUserFromCompetition error:', err);
+        console.error('[CompetitionService] deletePlayer error:', err);
         this.loader?.showToast?.('Errore rimozione giocatore', MSG_TYPE.ERROR);
         return EMPTY;
       }),
@@ -244,5 +244,7 @@ export class CompetitionService {
     this.store.clear();
     this.clearCompetitionsCache();
   }
-
+  removePlayerFromCompetition(competitionId: number | string, playerId: number | string): Observable<void> {
+    return this.api.deletePlayer(competitionId, playerId);
+  }
 }

--- a/src/style/style.scss
+++ b/src/style/style.scss
@@ -279,7 +279,6 @@ section {
         overflow: hidden;
         .close {
             top: 70px;
-            left: 75%;
         }
     }
 

--- a/src/style/utility.scss
+++ b/src/style/utility.scss
@@ -116,6 +116,7 @@ small.error {
     border: 0.0625em solid rgba($primary-light, 0.2);
     max-width: 500px;
     margin: 2em auto;
+
     h3 {
         font-size: 1.4rem;
         font-weight: 700;
@@ -152,6 +153,17 @@ small.error {
     }
 }
 
+.delete {
+    all: unset;
+    cursor: pointer;
+    background-color: $contrast;
+    border-radius: $border-radius;
+    display: grid;
+    place-items: center;
+    width: 1.5em;
+    height: 1.5em;
+}
+
 @keyframes scrollText {
     0% {
         transform: translateX(0);
@@ -160,4 +172,5 @@ small.error {
     100% {
         transform: translateX(-50%);
     }
+
 }


### PR DESCRIPTION
## Summary
- create a standalone group knockout component that combines league stats with the elimination bracket
- update the home view to switch between league, elimination, and the new hybrid mode while wiring outputs
- extend competition mode typings to cover group knockout competitions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2b6be9aac83228330af4e5d782318