### PR TITLE
feat: split group and knockout stages

### DIFF
--- a/public/lang.json
+++ b/public/lang.json
@@ -211,6 +211,14 @@
         "it": "Fase a gironi con eliminazione diretta finale (in arrivo).",
         "en": "Group phase followed by a knockout bracket (coming soon)."
     },
+    "group_knockout_board_title": {
+        "it": "Tabellone qualificati",
+        "en": "Qualified bracket"
+    },
+    "group_knockout_board_empty": {
+        "it": "Nessun giocatore qualificato al tabellone.",
+        "en": "No qualified players for the bracket."
+    },
     "beta_label": {
         "it": "Beta",
         "en": "Beta"

--- a/src/app/components/group-knockout/group-knockout-board.component.html
+++ b/src/app/components/group-knockout/group-knockout-board.component.html
@@ -1,0 +1,30 @@
+<section class="board" aria-labelledby="group-knockout-board-title">
+  <header class="board__header">
+    <h2 id="group-knockout-board-title" class="board__title">
+      {{ 'group_knockout_board_title' | translate }}
+    </h2>
+    <span class="board__count" *ngIf="players.length > 0">{{ players.length }}</span>
+  </header>
+
+  <ul class="board__list" *ngIf="players.length > 0; else emptyState">
+    <li class="board__item" *ngFor="let player of players; trackBy: trackByPlayer">
+      <div class="board__avatar" *ngIf="player.image_url; else initials">
+        <img [src]="player.image_url" [alt]="player.nickname || player.name" loading="lazy" />
+      </div>
+      <ng-template #initials>
+        <span class="board__avatar board__avatar--initials">{{ getInitials(player) }}</span>
+      </ng-template>
+
+      <div class="board__info">
+        <span class="board__name">{{ player.nickname || player.name }}</span>
+        <span class="board__meta" *ngIf="player.nickname && player.name">
+          {{ player.name }} <ng-container *ngIf="player.lastname">{{ player.lastname }}</ng-container>
+        </span>
+      </div>
+    </li>
+  </ul>
+
+  <ng-template #emptyState>
+    <p class="board__empty">{{ 'group_knockout_board_empty' | translate }}</p>
+  </ng-template>
+</section>

--- a/src/app/components/group-knockout/group-knockout-board.component.scss
+++ b/src/app/components/group-knockout/group-knockout-board.component.scss
@@ -1,0 +1,121 @@
+.board {
+  background: rgba(28, 30, 34, 0.7);
+  border-radius: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  backdrop-filter: blur(12px);
+}
+
+.board__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.board__title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.board__count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.board__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.board__item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.board__item:last-child {
+  border-bottom: none;
+}
+
+.board__avatar {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  overflow: hidden;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.1);
+  font-weight: 600;
+  color: #fff;
+  text-transform: uppercase;
+  font-size: 0.95rem;
+}
+
+.board__avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.board__avatar--initials {
+  letter-spacing: 0.02em;
+}
+
+.board__info {
+  display: flex;
+  flex-direction: column;
+}
+
+.board__name {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.board__meta {
+  font-size: 0.85rem;
+  opacity: 0.7;
+}
+
+.board__empty {
+  margin: 0;
+  font-size: 0.95rem;
+  opacity: 0.75;
+}
+
+@media (max-width: 48rem) {
+  .board {
+    padding: 1rem;
+  }
+
+  .board__title {
+    font-size: 1rem;
+  }
+
+  .board__item {
+    gap: 0.5rem;
+  }
+
+  .board__avatar {
+    width: 2.25rem;
+    height: 2.25rem;
+  }
+}

--- a/src/app/components/group-knockout/group-knockout-board.component.ts
+++ b/src/app/components/group-knockout/group-knockout-board.component.ts
@@ -1,0 +1,40 @@
+import { CommonModule } from '@angular/common';
+import { Component, Input } from '@angular/core';
+import { IPlayer } from '../../../services/players.service';
+import { TranslatePipe } from '../../utils/translate.pipe';
+
+@Component({
+  selector: 'app-group-knockout-board',
+  standalone: true,
+  imports: [CommonModule, TranslatePipe],
+  templateUrl: './group-knockout-board.component.html',
+  styleUrl: './group-knockout-board.component.scss'
+})
+export class GroupKnockoutBoardComponent {
+  @Input() players: IPlayer[] = [];
+
+  trackByPlayer(_index: number, player: IPlayer) {
+    return player.id;
+  }
+
+  getInitials(player: IPlayer): string {
+    const nickname = player.nickname ?? '';
+    const name = player.name ?? '';
+    const lastname = player.lastname ?? '';
+    const source = nickname || `${name} ${lastname}`.trim();
+
+    if (!source) {
+      return '?';
+    }
+
+    const parts = source.split(' ').filter(Boolean);
+    if (parts.length === 1) {
+      return parts[0].slice(0, 2).toUpperCase();
+    }
+
+    return parts
+      .slice(0, 2)
+      .map(part => part.charAt(0).toUpperCase())
+      .join('');
+  }
+}

--- a/src/app/components/group-knockout/group-knockout.component.html
+++ b/src/app/components/group-knockout/group-knockout.component.html
@@ -35,8 +35,13 @@
       <app-stats *ngIf="matches.length > 0"></app-stats>
     </section>
   </div>
-  <div class="wrapper" *ngIf="players.length >= 2">
+  <div class="wrapper" *ngIf="qualifiedPlayers.length >= 2; else eliminationEmpty">
+    <app-group-knockout-board [players]="qualifiedPlayers"></app-group-knockout-board>
     <app-elimination-bracket [competition]="competition" [rounds]="rounds"
       (playersSelected)="onRoundSelected($event)"></app-elimination-bracket>
   </div>
 </div>
+
+<ng-template #eliminationEmpty>
+  <p class="no-qualified text-center mt-3">{{ 'group_knockout_board_empty' | translate }}</p>
+</ng-template>

--- a/src/app/components/group-knockout/group-knockout.component.scss
+++ b/src/app/components/group-knockout/group-knockout.component.scss
@@ -20,6 +20,10 @@
   gap: 1.5em;
 }
 
+.no-qualified {
+  color: rgba(255, 255, 255, 0.6);
+}
+
 .buttons-home-matches {
   p {
     color: rgb(141, 142, 142);

--- a/src/app/components/group-knockout/group-knockout.component.ts
+++ b/src/app/components/group-knockout/group-knockout.component.ts
@@ -9,11 +9,19 @@ import { IPlayer } from '../../../services/players.service';
 import { ICompetition } from '../../../api/competition.api';
 import { TranslatePipe } from '../../utils/translate.pipe';
 import { ModalService } from '../../../services/modal.service';
+import { GroupKnockoutBoardComponent } from './group-knockout-board.component';
 
 @Component({
   selector: 'app-group-knockout',
   standalone: true,
-  imports: [CommonModule, MatchesComponent, StatsComponent, EliminationBracketComponent, TranslatePipe],
+  imports: [
+    CommonModule,
+    MatchesComponent,
+    StatsComponent,
+    EliminationBracketComponent,
+    GroupKnockoutBoardComponent,
+    TranslatePipe,
+  ],
   templateUrl: './group-knockout.component.html',
   styleUrl: './group-knockout.component.scss'
 })
@@ -21,6 +29,7 @@ export class GroupKnockoutComponent {
   @Input() matches: IMatch[] = [];
   @Input() rounds: EliminationRound[] = [];
   @Input() players: IPlayer[] = [];
+  @Input() qualifiedPlayers: IPlayer[] = [];
   @Input() competition: ICompetition | null = null;
 
   @Output() matchSelected = new EventEmitter<IMatch>();

--- a/src/app/components/home.component.html
+++ b/src/app/components/home.component.html
@@ -1,13 +1,13 @@
 <ng-container *ngIf="userState$ | async as state">
     <ng-container [ngSwitch]="activeCompetition?.type">
         <ng-container *ngSwitchCase="'elimination'">
-            <div class="wrapper" *ngIf="players.length >= 2 && activeCompetition">
+            <div class="wrapper" *ngIf="competitionQualifiedPlayers.length >= 2 && activeCompetition">
                 <app-elimination-bracket (playersSelected)="onClickRound($event)"
                     [competition]="activeCompetition" [rounds]="eliminationRounds"></app-elimination-bracket>
             </div>
         </ng-container>
         <app-group-knockout *ngSwitchCase="'group_knockout'" [competition]="activeCompetition"
-            [matches]="matches" [players]="players" [rounds]="eliminationRounds"
+            [matches]="matches" [players]="players" [qualifiedPlayers]="competitionQualifiedPlayers" [rounds]="eliminationRounds"
             (matchSelected)="setClickedMatch($event)" (roundSelected)="onClickRound($event)"></app-group-knockout>
         <ng-container *ngSwitchDefault>
             <div class="league-wrapper">


### PR DESCRIPTION
## Summary
- introduce a dedicated group knockout board component to list qualified players
- track qualified competition players separately and drive elimination rounds from that list
- update translations and templates to surface the qualified roster in group-knockout flow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3fc2e07b8832290bef9845239b4ab