### PR TITLE
Refine group knockout home layout and data sources

### DIFF
--- a/public/lang.json
+++ b/public/lang.json
@@ -215,6 +215,14 @@
         "it": "Tabellone",
         "en": "Bracket"
     },
+    "group_knockout_finals_title": {
+        "it": "Fase finali",
+        "en": "Final stage"
+    },
+    "group_knockout_finals_empty": {
+        "it": "La fase finale non è ancora disponibile.",
+        "en": "The final stage is not available yet."
+    },
     "group_knockout_board_empty": {
         "it": "Nessun giocatore qualificato al tabellone.",
         "en": "No qualified players for the bracket."

--- a/public/lang.json
+++ b/public/lang.json
@@ -212,8 +212,8 @@
         "en": "Group phase followed by a knockout bracket (coming soon)."
     },
     "group_knockout_board_title": {
-        "it": "Tabellone",
-        "en": "Bracket"
+        "it": "Fase a gironi",
+        "en": "Group stage"
     },
     "group_knockout_finals_title": {
         "it": "Fase finali",

--- a/public/lang.json
+++ b/public/lang.json
@@ -236,8 +236,8 @@
         "en": "Round"
     },
     "elimination_mode_description": {
-        "it": "Anteprima del tabellone: definisci gli accoppiamenti iniziali e preparati agli scontri diretti.",
-        "en": "Bracket preview: seed the initial matchups and get ready for direct elimination clashes."
+        "it": "Questa competizione è in modalità eliminazione diretta.",
+        "en": "This competition is in single elimination mode."
     },
     "elimination_waiting_player": {
         "it": "Chi sarà a passare il turno?",

--- a/src/app/common/stats/stats.component.html
+++ b/src/app/common/stats/stats.component.html
@@ -10,7 +10,7 @@
   <div class="win-rate" title="{{ 'ratingTitle' | translate }}">{{ "rating" | translate }}</div>
   <div class="win-rate" title="{{ 'winRateTitle' | translate }}">{{ "winRate" | translate }}</div>
 </div>
-<div *ngFor="let player of standings; let i = index; trackBy: trackByPlayer" class="stats-container mt-2 my-container">
+<div *ngFor="let player of standings; let i = index;" class="stats-container mt-2 my-container">
   <div class="position">
     <i *ngIf="i < 3" class="fa-solid fa-medal position-{{ i + 1 }}"></i> {{i+1}}
   </div>

--- a/src/app/common/stats/stats.component.scss
+++ b/src/app/common/stats/stats.component.scss
@@ -23,22 +23,18 @@ img {
 .stats-container {
   background: $dark;
   background: $gradient;
-  transform: skew(-20deg);
   padding: 0.5em 1em;
 
   &>img,
   div {
-    transform: skew(20deg);
     text-align: center;
   }
 
   .win-rate {
-    transform: skew(0);
   }
 
   .win-rate-bar {
     height: 0.3125em;
-    transform: skew(-20deg) !important;
     opacity: 0.75;
   }
 
@@ -140,7 +136,6 @@ img {
   position: relative;
   height: 0.75em;
   display: flex;
-  transform: skew(-30deg);
 }
 
 .bar {

--- a/src/app/components/add-match-modal/add-match-modal.component.ts
+++ b/src/app/components/add-match-modal/add-match-modal.component.ts
@@ -74,8 +74,8 @@ export class AddMatchModalComponent implements OnInit {
       date: [new Date().toISOString().split('T')[0], Validators.required],
       player1: [this.player1?.id, Validators.required],
       player2: [this.player2?.id, Validators.required],
-      p1Score: [null, [Validators.required, Validators.min(1), Validators.max(this.maxSets)]],
-      p2Score: [null, [Validators.required, Validators.min(1), Validators.max(this.maxSets)]],
+      p1Score: [null, [Validators.required, Validators.min(0), Validators.max(this.maxSets)]],
+      p2Score: [null, [Validators.required, Validators.min(0), Validators.max(this.maxSets)]],
       isShowSetsPointsTrue: [false],
       setsPoints: this.fb.array([]),
     });

--- a/src/app/components/add-players-modal/add-players-modal.component.ts
+++ b/src/app/components/add-players-modal/add-players-modal.component.ts
@@ -43,9 +43,9 @@ export class AddPlayersModalComponent extends ModalComponent {
   addPlayerForm: FormGroup = this.fb.group({
     name: [''],
     surname: [''],
-    nickname: ['', { validators: [Validators.required], updateOn: 'blur' }],
+    nickname: ['', { validators: [Validators.required], updateOn: 'change' }],
     file: [null],
-    email: ['', { validators: [Validators.email], updateOn: 'blur' }],
+    email: ['', { validators: [Validators.email], updateOn: 'change' }],
   });
 
   playersToAdd: IPlayerToAdd[] = [];

--- a/src/app/components/competitions/add-competition-modal/add-competition-modal.component.ts
+++ b/src/app/components/competitions/add-competition-modal/add-competition-modal.component.ts
@@ -54,7 +54,7 @@ export class AddCompetitionModalComponent {
 
     this.competitionForm = this.fb.group(
       {
-        nameCtrl: ['', [Validators.required, Validators.minLength(3)]],
+        nameCtrl: ['', [Validators.required, Validators.minLength(3), Validators.maxLength(20)]],
         typeCtrl: [null, Validators.required],
         setsCtrl: [null, Validators.required],
         pointsCtrl: [null, Validators.required],

--- a/src/app/components/competitions/competition-detail/competition-detail.component.html
+++ b/src/app/components/competitions/competition-detail/competition-detail.component.html
@@ -70,8 +70,3 @@
                             ]" (actionSelected)="onDropdownAction($event)"></app-dropdown>
 </div>
 
-<app-modal [label]="'are_you_sure'" *ngIf="areYouSureVisible"
-  [modalName]="modalService.MODALS['ARE_YOU_SURE']"
-  (closeModalEvent)="areYouSureVisible = false">
-  <are-you-sure [body]="'are-you-sure-deleting' | translate" (confirmed)="onDeleteConfirmed()" (cancelled)="onDeleteCancelled()"></are-you-sure>
-</app-modal>

--- a/src/app/components/competitions/competition-detail/competition-detail.component.ts
+++ b/src/app/components/competitions/competition-detail/competition-detail.component.ts
@@ -19,7 +19,7 @@ import { ElementRef, ViewChild } from '@angular/core';
 export class CompetitionDetailComponent {
 
   @Input() competition: ICompetition | null = null;
-  areYouSureVisible: boolean = false;
+
   playerIdToDelete: number = -1;
 
   @ViewChild('competitionDetail', { static: true }) competitionDetailRef!: ElementRef<HTMLElement>;
@@ -109,13 +109,13 @@ export class CompetitionDetailComponent {
   }
   openAreYouSureModal(playerId: number) {
     this.playerIdToDelete = playerId;
-    this.areYouSureVisible = true;
+    this.modalService.openModal(this.modalService.MODALS['ARE_YOU_SURE']);
   }
   onDeleteConfirmed() {
-    this.areYouSureVisible = false;
+    this.modalService.closeModal();
     this.deletePlayer(this.playerIdToDelete);
   }
   onDeleteCancelled() {
-    this.areYouSureVisible = false;
+    this.modalService.closeModal();
   }
 }

--- a/src/app/components/competitions/competition-detail/competition-detail.component.ts
+++ b/src/app/components/competitions/competition-detail/competition-detail.component.ts
@@ -12,7 +12,7 @@ import { ElementRef, ViewChild } from '@angular/core';
 
 @Component({
   selector: 'app-competition-detail',
-  imports: [...SHARED_IMPORTS, ModalComponent, AreYouSureComponent],
+  imports: [...SHARED_IMPORTS],
   templateUrl: './competition-detail.component.html',
   styleUrl: './competition-detail.component.scss'
 })

--- a/src/app/components/competitions/competitions/competitions.component.html
+++ b/src/app/components/competitions/competitions/competitions.component.html
@@ -121,9 +121,16 @@
         <app-edit-competition-modal></app-edit-competition-modal>
     </app-modal>
 
-    <app-modal [transparent]="true" [isSmall]="true" [label]="''" *ngIf="modalService.isActiveModal(modalService.MODALS['VIEW_COMPETITION'])"
+    <app-modal [transparent]="true" [isSmall]="true" [label]="''"
+        *ngIf="modalService.isActiveModal(modalService.MODALS['VIEW_COMPETITION'])"
         [modalName]="modalService.MODALS['VIEW_COMPETITION']">
         <app-view-competition-modal [competition]="competitionDetail"></app-view-competition-modal>
+    </app-modal>
+
+    <app-modal [label]="'are_you_sure'" *ngIf="modalService.isActiveModal(modalService.MODALS['ARE_YOU_SURE'])"
+        [modalName]="modalService.MODALS['ARE_YOU_SURE']" (closeModalEvent)="modalService.closeModal()">
+        <are-you-sure [body]="'are-you-sure-deleting' | translate" (confirmed)="onDeleteConfirmed()"
+            (cancelled)="onDeleteCancelled()"></are-you-sure>
     </app-modal>
 </ng-container>
 

--- a/src/app/components/competitions/competitions/competitions.component.ts
+++ b/src/app/components/competitions/competitions/competitions.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, ViewChild } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup, FormsModule } from '@angular/forms';
 import { combineLatest, map } from 'rxjs';
 import { SHARED_IMPORTS } from '../../../common/imports/shared.imports';
@@ -17,6 +17,7 @@ import { Utils } from '../../../utils/Utils';
 import { JoinCompetitionModalComponent } from '../../join-competition-modal/join-competition-modal.component';
 import { ViewCompetitionModalComponent } from './view-competition-modal/view-competition-modal.component';
 import { EditCompetitionModalComponent } from './edit-competition-modal/edit-competition-modal.component';
+import { AreYouSureComponent } from '../../../common/are-you-sure/are-you-sure.component';
 @Component({
   selector: 'app-competitions',
   standalone: true,
@@ -31,12 +32,15 @@ import { EditCompetitionModalComponent } from './edit-competition-modal/edit-com
     AddPlayersModalComponent,
     JoinCompetitionModalComponent,
     ViewCompetitionModalComponent,
-    EditCompetitionModalComponent
+    EditCompetitionModalComponent,
+    AreYouSureComponent
   ],
   templateUrl: './competitions.component.html',
   styleUrls: ['./competitions.component.scss']
 })
 export class CompetitionsComponent {
+
+  @ViewChild(CompetitionDetailComponent) competitionDetailComponent!: CompetitionDetailComponent;
   PROGRESS_STATE = UserProgressStateEnum;
   // services
   userService = inject(UserService);
@@ -120,5 +124,11 @@ export class CompetitionsComponent {
       competitions.filter(c => c.id !== active?.id)
     )
   );
-
+  onDeleteConfirmed() {
+    this.modalService.closeModal();
+    this.competitionDetailComponent.onDeleteConfirmed();
+  }
+  onDeleteCancelled() {
+    this.modalService.closeModal();
+  }
 }

--- a/src/app/components/elimination-bracket/elimination-bracket.component.html
+++ b/src/app/components/elimination-bracket/elimination-bracket.component.html
@@ -2,7 +2,7 @@
   <header class="elimination-header">
     <div>
       <h2>{{ active.name }}</h2>
-      <p>{{ 'elimination_mode_description' | translate }}</p>
+      <p class="text-center">{{ 'elimination_mode_description' | translate }}</p>
     </div>
     <div class="meta">
       <div class="meta-item">

--- a/src/app/components/group-knockout/group-knockout-board.component.html
+++ b/src/app/components/group-knockout/group-knockout-board.component.html
@@ -3,7 +3,7 @@
     <h2 id="group-knockout-board-title" class="board__title">
       {{ 'group_knockout_board_title' | translate }}
     </h2>
-    <span class="board__count" *ngIf="players.length">{{ players.length }}</span>
+    <span class="board__count" *ngIf="players.length">{{ players.length }} {{ 'players' | translate }}</span>
   </header>
 
   <ng-container *ngIf="groupedPlayers?.length; else emptyState">

--- a/src/app/components/group-knockout/group-knockout-board.component.scss
+++ b/src/app/components/group-knockout/group-knockout-board.component.scss
@@ -21,6 +21,19 @@
   gap: 1rem;
 }
 
+#group-knockout-board-title {
+  font-size: 2em;
+
+  &::before {
+    display: inline-block;
+    content: '';
+    width: 0.5rem;
+    height: 0.5rem;
+    border-radius: 50%;
+    background: $orange;
+  }
+}
+
 .board__title {
   font-size: 1.1rem;
   font-weight: 600;
@@ -105,6 +118,7 @@
   font-size: 0.95rem;
   opacity: 0.75;
 }
+
 .board__table {
   display: flex;
   flex-direction: column;
@@ -126,7 +140,7 @@
   font-weight: 700;
   font-size: 0.98rem;
   background: $background-harmony;
-  border-bottom: 1px solid rgba(255,255,255,0.08);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .board__table-row {
@@ -171,16 +185,19 @@
 }
 
 @media (max-width: 48rem) {
+
   .board__table-header,
   .board__table-row {
     grid-template-columns: 2fr 1fr 1fr 1fr;
     font-size: 0.93rem;
     padding: 0.4rem 0.5rem;
   }
+
   .board__group-title {
     font-size: 0.98rem;
   }
 }
+
 @media (max-width: 48rem) {
   .board {
     padding: 1rem;

--- a/src/app/components/group-knockout/group-knockout-board.component.scss
+++ b/src/app/components/group-knockout/group-knockout-board.component.scss
@@ -173,7 +173,7 @@
   min-width: 1.5rem;
   text-align: center;
   font-weight: 600;
-  color: $primary;
+  color: $primary-ultra-light;
 }
 
 .board__group-title {

--- a/src/app/components/group-knockout/group-knockout-board.component.ts
+++ b/src/app/components/group-knockout/group-knockout-board.component.ts
@@ -2,6 +2,7 @@ import { CommonModule } from '@angular/common';
 import { Component, Input, OnChanges } from '@angular/core';
 import { IPlayer } from '../../../services/players.service';
 import { TranslatePipe } from '../../utils/translate.pipe';
+import { ModalService } from '../../../services/modal.service';
 
 interface PlayerRow {
   id: string;
@@ -32,6 +33,7 @@ export class GroupKnockoutBoardComponent implements OnChanges {
 
   groupedPlayers: GroupedPlayers[] = [];
 
+  constructor(public modalService: ModalService) { }
   ngOnChanges() {
     this.groupPlayers();
   }

--- a/src/app/components/group-knockout/group-knockout.component.html
+++ b/src/app/components/group-knockout/group-knockout.component.html
@@ -1,49 +1,41 @@
 <div class="group-knockout-wrapper">
-  <div class="league-wrapper">
-    <p *ngIf="matches.length === 0" class="mt-4 text-center">
-      {{ 'matches_not_found' | translate }}
-    </p>
-    <section style="padding: 0;">
-      <app-matches *ngIf="matches.length > 0" [matches]="matches" (matchEmitter)="onMatchSelected($event)">
-      </app-matches>
-      <div class="buttons-home-matches">
-        <div class="button-container mt-3">
-          <button type="button" (click)="modalService.openModal(modalService.MODALS['ADD_MATCH'])" class="add-match">
-            {{ 'add_match' | translate }}
-            <span class="m-1"></span>
-            <i class="fa fa-file-text-o" aria-hidden="true"></i>
-          </button>
-          <p class="small text-center mt-3">
-            {{ 'add_match_description' | translate }}
-          </p>
-        </div>
-        <div class="button-container">
-          <div>
-            <button type="button" class="bg-secondary position-relative"
-              (click)="modalService.openModal(modalService.MODALS['MANUAL_POINTS'])">
-              {{ 'add_manual_set_points' | translate }}
-              <div class="circle-live"></div>
-            </button>
-          </div>
-          <p class="small text-center mt-3">
-            {{ 'add_manual_set_points_description' | translate }}
-          </p>
-        </div>
+  <section class="board-section">
+    <app-group-knockout-board [players]="boardPlayers"></app-group-knockout-board>
+    <div class="buttons-home-matches" aria-label="group-knockout-actions">
+      <div class="button-container mt-3">
+        <button type="button" (click)="modalService.openModal(modalService.MODALS['ADD_MATCH'])" class="add-match">
+          {{ 'add_match' | translate }}
+          <span class="m-1"></span>
+          <i class="fa fa-file-text-o" aria-hidden="true"></i>
+        </button>
+        <p class="small text-center mt-3">
+          {{ 'add_match_description' | translate }}
+        </p>
       </div>
-    </section>
+      <div class="button-container">
+        <div>
+          <button type="button" class="bg-secondary position-relative"
+            (click)="modalService.openModal(modalService.MODALS['MANUAL_POINTS'])">
+            {{ 'add_manual_set_points' | translate }}
+            <div class="circle-live"></div>
+          </button>
+        </div>
+        <p class="small text-center mt-3">
+          {{ 'add_manual_set_points_description' | translate }}
+        </p>
+      </div>
+    </div>
+  </section>
 
-  </div>
-  <div *ngIf="qualifiedPlayers.length >= 2; else eliminationEmpty">
-    <section class="mb-5">
-      <app-group-knockout-board [players]="qualifiedPlayers"></app-group-knockout-board>
-    </section>
-    <section>
+  <section class="finals-section">
+    <h2 class="finals-section__title">{{ 'group_knockout_finals_title' | translate }}</h2>
+    <ng-container *ngIf="qualifiedPlayers.length >= 2 && rounds.length > 0; else eliminationEmpty">
       <app-elimination-bracket [competition]="competition" [rounds]="rounds"
         (playersSelected)="onRoundSelected($event)"></app-elimination-bracket>
-    </section>
-  </div>
+    </ng-container>
+  </section>
 </div>
 
 <ng-template #eliminationEmpty>
-  <p class="no-qualified text-center mt-3">{{ 'group_knockout_board_empty' | translate }}</p>
+  <p class="no-qualified text-center mt-3">{{ 'group_knockout_finals_empty' | translate }}</p>
 </ng-template>

--- a/src/app/components/group-knockout/group-knockout.component.html
+++ b/src/app/components/group-knockout/group-knockout.component.html
@@ -1,5 +1,5 @@
-<div class="group-knockout-wrapper">
-  <section class="board-section">
+<div class="group-knockout-wrapper pt-5">
+  <section class="board-section mt-5">
     <app-group-knockout-board [players]="boardPlayers"></app-group-knockout-board>
     <div class="buttons-home-matches" aria-label="group-knockout-actions">
       <div class="button-container mt-3">

--- a/src/app/components/group-knockout/group-knockout.component.scss
+++ b/src/app/components/group-knockout/group-knockout.component.scss
@@ -41,6 +41,11 @@
   }
 }
 
+.buttons-home-matches {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+}
+
 @media screen and (max-width: 62.5em) {
   .buttons-home-matches {
     flex-direction: column;

--- a/src/app/components/group-knockout/group-knockout.component.scss
+++ b/src/app/components/group-knockout/group-knockout.component.scss
@@ -2,21 +2,28 @@
   display: block;
 }
 
+
 .group-knockout-wrapper {
   display: flex;
   flex-direction: column;
+  gap: 2.5rem;
 }
 
-.league-wrapper {
+.board-section {
   display: flex;
   flex-direction: column;
-  gap: 1.5em;
+  gap: 1.5rem;
 }
 
-.wrapper {
+.finals-section {
   display: flex;
   flex-direction: column;
-  gap: 1.5em;
+  gap: 1.5rem;
+}
+
+.finals-section__title {
+  font-size: 1.5rem;
+  font-weight: 600;
 }
 
 .no-qualified {
@@ -24,13 +31,17 @@
 }
 
 .buttons-home-matches {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+
   p {
     color: rgb(141, 142, 142);
   }
 }
 
 @media screen and (max-width: 62.5em) {
-  .wrapper {
-    margin-top: 4.6em;
+  .buttons-home-matches {
+    flex-direction: column;
   }
 }

--- a/src/app/components/group-knockout/group-knockout.component.scss
+++ b/src/app/components/group-knockout/group-knockout.component.scss
@@ -34,7 +34,8 @@
   display: flex;
   flex-wrap: wrap;
   gap: 1.5rem;
-
+  max-width: 1000px;
+  margin: auto;
   p {
     color: rgb(141, 142, 142);
   }

--- a/src/app/components/group-knockout/group-knockout.component.ts
+++ b/src/app/components/group-knockout/group-knockout.component.ts
@@ -1,8 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { Component, EventEmitter, Input, Output, inject } from '@angular/core';
-import { MatchesComponent } from '../matches/matches.component';
 import { EliminationBracketComponent, EliminationModalEvent } from '../elimination-bracket/elimination-bracket.component';
-import { IMatch } from '../../interfaces/matchesInterfaces';
 import { EliminationRound } from '../../interfaces/elimination-bracket.interface';
 import { IPlayer } from '../../../services/players.service';
 import { ICompetition } from '../../../api/competition.api';
@@ -15,7 +13,6 @@ import { GroupKnockoutBoardComponent } from './group-knockout-board.component';
   standalone: true,
   imports: [
     CommonModule,
-    MatchesComponent,
     EliminationBracketComponent,
     GroupKnockoutBoardComponent,
     TranslatePipe,
@@ -24,20 +21,14 @@ import { GroupKnockoutBoardComponent } from './group-knockout-board.component';
   styleUrl: './group-knockout.component.scss'
 })
 export class GroupKnockoutComponent {
-  @Input() matches: IMatch[] = [];
   @Input() rounds: EliminationRound[] = [];
-  @Input() players: IPlayer[] = [];
+  @Input() boardPlayers: IPlayer[] = [];
   @Input() qualifiedPlayers: IPlayer[] = [];
   @Input() competition: ICompetition | null = null;
 
-  @Output() matchSelected = new EventEmitter<IMatch>();
   @Output() roundSelected = new EventEmitter<EliminationModalEvent>();
 
   modalService = inject(ModalService);
-
-  onMatchSelected(match: IMatch) {
-    this.matchSelected.emit(match);
-  }
 
   onRoundSelected(event: EliminationModalEvent) {
     this.roundSelected.emit(event);

--- a/src/app/components/home.component.html
+++ b/src/app/components/home.component.html
@@ -7,8 +7,8 @@
             </div>
         </ng-container>
         <app-group-knockout *ngSwitchCase="'group_knockout'" [competition]="activeCompetition"
-            [matches]="matches" [players]="players" [qualifiedPlayers]="competitionQualifiedPlayers" [rounds]="eliminationRounds"
-            (matchSelected)="setClickedMatch($event)" (roundSelected)="onClickRound($event)"></app-group-knockout>
+            [boardPlayers]="groupStagePlayers" [qualifiedPlayers]="competitionQualifiedPlayers"
+            [rounds]="eliminationRounds" (roundSelected)="onClickRound($event)"></app-group-knockout>
         <ng-container *ngSwitchDefault>
             <div class="league-wrapper">
                 <p *ngIf="matches.length === 0" class="mt-4 text-center">
@@ -56,7 +56,7 @@
 
 <app-modal [label]="'add_match'" *ngIf="modalService.isActiveModal(modalService.MODALS['ADD_MATCH'])"
     [modalName]="modalService.MODALS['ADD_MATCH']">
-    <add-match-modal [isAlreadySelected]="!!player1Selected && !!player2Selected" [players]="players"
+    <add-match-modal [isAlreadySelected]="!!player1Selected && !!player2Selected" [players]="modalPlayers"
         [player1]="player1Selected" [player2]="player2Selected"></add-match-modal>
 </app-modal>
 
@@ -68,6 +68,6 @@
 <app-modal [fullscreen]="true" [label]="'manual_points'"
     *ngIf="modalService.isActiveModal(modalService.MODALS['MANUAL_POINTS'])"
     [modalName]="modalService.MODALS['MANUAL_POINTS']" class="manual-points-modal">
-    <app-manual-points [isAlreadySelected]="!!player1Selected && !!player2Selected" [players]="players"
+    <app-manual-points [isAlreadySelected]="!!player1Selected && !!player2Selected" [players]="modalPlayers"
         [player1]="player1Selected" [player2]="player2Selected"></app-manual-points>
 </app-modal>

--- a/src/app/components/home.component.ts
+++ b/src/app/components/home.component.ts
@@ -250,8 +250,8 @@ export class HomeComponent {
   private refreshCompetitionQualifiedPlayers() {
     const qualifiedFromCompetition = this.extractCompetitionPlayers(
       (this.activeCompetition as any)?.qualifiedPlayers
-        ?? (this.activeCompetition as any)?.qualified_players
-        ?? null
+      ?? (this.activeCompetition as any)?.qualified_players
+      ?? null
     );
 
     if (qualifiedFromCompetition.length > 0) {
@@ -486,5 +486,13 @@ export class HomeComponent {
     }
 
     this.modalService.openModal(this.modalService.MODALS[event.modalName]);
+  }
+
+  get canStartElimination(): boolean {
+    return !!this.activeCompetition && this.competitionQualifiedPlayers.length >= 2;
+  }
+
+  get hasMatches(): boolean {
+    return this.matches?.length > 0;
   }
 }

--- a/src/app/interfaces/responsesInterfaces.ts
+++ b/src/app/interfaces/responsesInterfaces.ts
@@ -1,5 +1,8 @@
+import { IMatch } from './matchesInterfaces';
+
 export interface IMatchResponse {
-  matches: any;
+  matches: IMatch[] | any;
+  matchesElimination?: IMatch[] | null;
   points: any;
   totPlayed: {};
   wins: {};

--- a/src/services/data.service.ts
+++ b/src/services/data.service.ts
@@ -10,6 +10,7 @@ import { BehaviorSubject, firstValueFrom } from 'rxjs';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { API_PATHS } from '../api/api.config';
 import { UserService } from './user.service';
+import { RankingService } from './ranking.service';
 
 interface MatchData extends IMatchResponse {
   matches: IMatch[];
@@ -75,6 +76,7 @@ export class DataService {
   private _id = Math.random().toString(36).slice(2);
 
   private userService = inject(UserService);
+  private rankingService = inject(RankingService);
 
   constructor(private loaderService: LoaderService, private http: HttpClient) {
     console.log('[DataService] ctor', this._id);
@@ -219,6 +221,8 @@ export class DataService {
       this.loaderService?.showToast('Salvato con successo!', MSG_TYPE.SUCCESS, 5000);
       this.matches = responseData.matches || [];
       this.matchesSubject.next(this.matches);
+      this.rankingService.triggerRefresh();
+
       console.log('Success:', responseData);
     } catch (error: any) {
       console.info('Error:', error);

--- a/src/services/data.service.ts
+++ b/src/services/data.service.ts
@@ -13,6 +13,7 @@ import { UserService } from './user.service';
 
 interface MatchData extends IMatchResponse {
   matches: IMatch[];
+  matchesElimination?: IMatch[] | null;
   wins: Record<string, number>;
   totPlayed: Record<string, number>;
   points: any;
@@ -52,17 +53,20 @@ export class DataService {
   players: string[] = [];
   loader!: LoaderComponent;
   points: any;
+  matchesElimination: IMatch[] = [];
 
   private winsSubject = new BehaviorSubject<Record<string, number>>({});
   private totPlayedSubject = new BehaviorSubject<Record<string, number>>({});
   private pointsSubject = new BehaviorSubject<Record<string, number>>({});
   private matchesSubject = new BehaviorSubject<IMatch[]>([]);
+  private matchesEliminationSubject = new BehaviorSubject<IMatch[]>([]);
   private playersSubject = new BehaviorSubject<string[]>([]);
 
   public winsObs = this.winsSubject.asObservable();
   public totPlayedObs = this.totPlayedSubject.asObservable();
   public pointsObs = this.pointsSubject.asObservable();
   public matchesObs = this.matchesSubject.asObservable();
+  public matchesEliminationObs = this.matchesEliminationSubject.asObservable();
   public playersObs = this.playersSubject.asObservable();
 
   private _loaded = false;                 // abbiamo già i dati?
@@ -155,11 +159,13 @@ export class DataService {
     this.totPlayed = data.totPlayed || {};
     this.points = data.points || {};
     this.players = data.players || [];
+    this.matchesElimination = data.matchesElimination || [];
     this.monthlyWinRates = data.monthlyWinRates || {};
     this.badges = data.badges || {};
 
     // 👉 aggiorna gli stream reattivi
     this.matchesSubject.next(this.matches);
+    this.matchesEliminationSubject.next(this.matchesElimination);
     this.winsSubject.next(this.wins);
     this.totPlayedSubject.next(this.totPlayed);
     this.pointsSubject.next(this.points);
@@ -169,6 +175,7 @@ export class DataService {
   private generateReturnObject(): MatchData {
     return {
       matches: this.matches,
+      matchesElimination: this.matchesElimination,
       wins: this.wins,
       totPlayed: this.totPlayed,
       points: this.points,

--- a/src/services/modal.service.ts
+++ b/src/services/modal.service.ts
@@ -42,8 +42,10 @@ export class ModalService {
     document?.querySelector('html')?.style.removeProperty('overflow');
     document?.querySelector('html')?.style.setProperty('margin-right', '0');
     let wrapper = document.querySelector('.wrapper') as HTMLElement;
-    wrapper.style.removeProperty('filter');
-    wrapper.style.removeProperty('pointer-events');
-    wrapper.style.removeProperty('user-select');
+    if (wrapper) {
+      wrapper.style.removeProperty('filter');
+      wrapper.style.removeProperty('pointer-events');
+      wrapper.style.removeProperty('user-select');
+    }
   }
 }

--- a/src/services/ranking.service.ts
+++ b/src/services/ranking.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { firstValueFrom } from 'rxjs';
+import { firstValueFrom, Subject } from 'rxjs';
 import { HttpClient } from '@angular/common/http';
 import { IRankingResponse } from './data.service';
 import { API_PATHS } from '../api/api.config';
@@ -7,9 +7,12 @@ import { environment } from '../environments/environment';
 import { CachedFetcher } from '../app/utils/helpers/cache.helpers'
 @Injectable({ providedIn: 'root' })
 export class RankingService {
+
+  private refresh$ = new Subject<void>();
+  refreshObs$ = this.refresh$.asObservable();
   private fetcherMap: Map<string, CachedFetcher<IRankingResponse>> = new Map();
 
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient) { }
 
   private getFetcher(competition_id: string): CachedFetcher<IRankingResponse> {
     if (!this.fetcherMap.has(competition_id)) {
@@ -36,5 +39,9 @@ export class RankingService {
     if (fetcher) {
       fetcher.clear();
     }
+  }
+
+  triggerRefresh() {
+    this.refresh$.next();
   }
 }


### PR DESCRIPTION
## Summary
- restructure the group knockout home view to focus on the board with quick actions and a dedicated finals section
- drive elimination brackets from the new matchesElimination stream and filter modal players to the active board participants
- surface matchesElimination from the data service and extend translations for the finals messaging

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d40b6c21f4832283e11b5b1a51bfe3