### PR TITLE
Improve match modal best-of validation

### DIFF
--- a/public/lang.json
+++ b/public/lang.json
@@ -363,6 +363,10 @@
         "it": "Al meglio di",
         "en": "Best of"
     },
+    "best_of_invalid": {
+        "it": "Risultato non valido: il vincitore deve raggiungere i set previsti.",
+        "en": "Invalid result: the winner must reach the required number of sets."
+    },
     "points_number": {
         "it": "Punti a",
         "en": "Points to"


### PR DESCRIPTION
## Summary
- enforce best-of match validation in the add match modal so only legal ping pong set combinations are allowed
- adjust dynamic validators and set inputs to reflect the configured maximum sets
- add a translation for the new best-of validation error message

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4679f26d08322a47c18087226b485