### PR TITLE
Fix profile completion state updates

### DIFF
--- a/src/app/components/profile/complete-profile/complete-profile.component.ts
+++ b/src/app/components/profile/complete-profile/complete-profile.component.ts
@@ -61,8 +61,8 @@ export class CompleteProfileComponent implements OnInit {
     await firstValueFrom(this.userService.getState());
     console.log('User state fetched:', this.userService.getState());
     this.userState$.subscribe(s => {
-      if (s.state === UserProgressStateEnum.PROFILE_COMPLETED) {
-        this.router.navigate(['/competition']);
+      if (s?.state === UserProgressStateEnum.PROFILE_COMPLETED) {
+        this.router.navigate(['/competitions']);
       }
     });
   }
@@ -146,9 +146,15 @@ export class CompleteProfileComponent implements OnInit {
       }
 
       // 5) salva profilo
-      await firstValueFrom(
+      const response = await firstValueFrom(
         this.http.post<UpdateProfileResponse>(API_PATHS.updateProfile, { nickname, imageUrl })
       );
+
+      this.userService.patchLocal({
+        nickname: response.nickname,
+        image_url: response.imageUrl ?? null,
+        state: response.state,
+      });
 
       this.loaderService?.showToast('Profilo aggiornato!', MSG_TYPE.SUCCESS, 3000);
       this.router.navigate(['/competitions']);

--- a/src/app/components/profile/profile/profile.component.ts
+++ b/src/app/components/profile/profile/profile.component.ts
@@ -172,9 +172,15 @@ export class ProfileComponent implements OnInit, OnDestroy {
         }
       }
 
-      await firstValueFrom(
+      const response = await firstValueFrom(
         this.http.post<UpdateProfileResponse>(API_PATHS.updateProfile, { nickname, imageUrl })
       );
+
+      this.userService.patchLocal({
+        nickname: response.nickname,
+        image_url: response.imageUrl ?? null,
+        state: response.state,
+      });
 
       this.loader.showToast('Profilo aggiornato!', MSG_TYPE.SUCCESS, 3000);
     } catch (err) {

--- a/src/services/interfaces/Interfaces.ts
+++ b/src/services/interfaces/Interfaces.ts
@@ -36,7 +36,7 @@ export interface IUserState {
   updated_at: string; // ISO 8601
   nickname: string;
   player_id: number;
-  image_url: string;
+  image_url: string | null;
   email: string;
   name: string | null;
   lastname: string | null;


### PR DESCRIPTION
## Summary
- allow the cached user state to store a nullable avatar URL
- refresh the local user store after completing or editing the profile so navigation reflects the new status
- align the complete-profile redirect when the profile has already been completed

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d467dfb29c8322813fea7bf6395ab2