### PR TITLE
Add manual match date input for elimination mode

### DIFF
--- a/src/app/components/add-match-modal/manual-points/manual-points.component.html
+++ b/src/app/components/add-match-modal/manual-points/manual-points.component.html
@@ -47,6 +47,16 @@
                 {{ 'manual_points_description' | translate }}
             </p>
 
+            <div class="row justify-content-center mb-4">
+                <div class="col-12 col-md-6">
+                    <label for="manual-match-date" class="my-placeholder d-block text-center text-md-start mb-2">
+                        {{ 'date' | translate }}
+                    </label>
+                    <input id="manual-match-date" type="date" class="my-placeholder w-100" formControlName="date"
+                        required>
+                </div>
+            </div>
+
             <div class="row align-items-center justify-content-center">
                 <!-- Player 1 -->
                 <div class="col-12 col-md-5 mb-3 mb-md-0">
@@ -78,6 +88,10 @@
     </div>
 
     <div *ngIf="isCompleted()">
+        <p class="text-center" *ngIf="matchDate">
+            {{ 'date' | translate }}:
+            {{ matchDate | date: 'dd/MM/yyyy' }}
+        </p>
         <div class="summary mt-5" *ngIf="sets.length > 0">
             <h3>{{ 'match_summary' | translate }}</h3>
             <ul>


### PR DESCRIPTION
## Summary
- add a date picker to the manual points modal used for direct elimination matches
- persist the selected day when saving a manual match and display it in the summary
- derive the stored match date string from the chosen calendar day while keeping the current time component

## Testing
- `npm run test -- --watch=false --browsers=ChromeHeadless` *(fails: Cannot resolve ./modal.component.css?ngResource)*

------
https://chatgpt.com/codex/tasks/task_e_68d46820bf208322b21559e5455c8404