### PR TITLE
feat: localize marketing landing page

### DIFF
--- a/public/lang.json
+++ b/public/lang.json
@@ -888,6 +888,262 @@
     "player_removed": {
         "it": "Giocatore rimosso con successo.",
         "en": "Player removed successfully."
+    },
+    "landing_hero_badge": {
+        "it": "La dashboard dei tornei di ping pong",
+        "en": "The ping pong tournament dashboard"
+    },
+    "landing_hero_title_prefix": {
+        "it": "Organizza, segui e fai crescere ogni sfida con",
+        "en": "Organize, track and grow every challenge with"
+    },
+    "landing_hero_lead": {
+        "it": "Dal primo match all'ultimo smash: un'esperienza fluida per club, community e professionisti che vogliono una regia impeccabile, dati smart e coinvolgimento continuo.",
+        "en": "From the first match to the last smash: a seamless experience for clubs, communities and professionals who want flawless orchestration, smart data and continuous engagement."
+    },
+    "landing_hero_cta_primary": {
+        "it": "Inizia ora",
+        "en": "Start now"
+    },
+    "landing_hero_cta_secondary": {
+        "it": "Accedi",
+        "en": "Log in"
+    },
+    "landing_hero_cta_tertiary": {
+        "it": "Scopri di più",
+        "en": "Learn more"
+    },
+    "landing_hero_social_proof": {
+        "it": "Oltre 120 club hanno già digitalizzato i loro tornei con noi.",
+        "en": "Over 120 clubs have already digitized their tournaments with us."
+    },
+    "landing_preview_title": {
+        "it": "Competizione Elite - Round Finale",
+        "en": "Elite Competition - Final Round"
+    },
+    "landing_preview_status": {
+        "it": "Live",
+        "en": "Live"
+    },
+    "landing_preview_team_one": {
+        "it": "Team Smash",
+        "en": "Team Smash"
+    },
+    "landing_preview_team_two": {
+        "it": "Spin Masters",
+        "en": "Spin Masters"
+    },
+    "landing_preview_ranking_one": {
+        "it": "Ranking #1",
+        "en": "Ranking #1"
+    },
+    "landing_preview_ranking_two": {
+        "it": "Ranking #2",
+        "en": "Ranking #2"
+    },
+    "landing_preview_progress": {
+        "it": "Set 4 - Analisi in corso",
+        "en": "Set 4 - Analysis in progress"
+    },
+    "landing_preview_footer_label": {
+        "it": "Aggiornamento automatico",
+        "en": "Automatic update"
+    },
+    "landing_preview_footer_highlight": {
+        "it": "Statistiche sincronizzate",
+        "en": "Synced stats"
+    },
+    "landing_preview_footer_cta": {
+        "it": "Entra nella dashboard",
+        "en": "Enter the dashboard"
+    },
+    "landing_features_title": {
+        "it": "Il quartier generale della tua community pongistica",
+        "en": "The headquarters for your ping pong community"
+    },
+    "landing_features_subtitle": {
+        "it": "Tutto quello che ti serve per creare esperienze di gioco memorabili: workflow guidati, automazioni e storytelling visivo pensati da coach, arbitri e marketer.",
+        "en": "Everything you need to craft memorable playing experiences: guided workflows, automations and visual storytelling designed by coaches, referees and marketers."
+    },
+    "landing_features_highlight_cta": {
+        "it": "Attiva subito",
+        "en": "Activate now"
+    },
+    "landing_highlight_management_title": {
+        "it": "Gestione intuitiva delle competizioni",
+        "en": "Intuitive competition management"
+    },
+    "landing_highlight_management_description": {
+        "it": "Crea tornei a gironi o ad eliminazione, personalizza regole e lascia che la piattaforma pensi a calendario e classifiche.",
+        "en": "Create round robin or knockout tournaments, customize rules and let the platform handle schedules and leaderboards."
+    },
+    "landing_highlight_tracking_title": {
+        "it": "Match tracking in tempo reale",
+        "en": "Real-time match tracking"
+    },
+    "landing_highlight_tracking_description": {
+        "it": "Aggiorna risultati e statistiche live, sincronizzati con tutti i dispositivi della tua squadra o del tuo club.",
+        "en": "Update results and stats live, synced across every device in your team or club."
+    },
+    "landing_highlight_insights_title": {
+        "it": "Insights da coach professionista",
+        "en": "Insights like a pro coach"
+    },
+    "landing_highlight_insights_description": {
+        "it": "Analizza performance, identifica i trend dei giocatori e prepara le prossime sfide con report visivi e smart analytics.",
+        "en": "Analyze performance, spot player trends and prep the next challenges with visual reports and smart analytics."
+    },
+    "landing_journey_title": {
+        "it": "Dalla registrazione al torneo completo in 3 step",
+        "en": "From registration to a full tournament in 3 steps"
+    },
+    "landing_journey_subtitle": {
+        "it": "Un flusso progettato per accompagnare organizzatori, responsabili marketing e tecnici di squadra in ogni decisione.",
+        "en": "A flow designed to guide organizers, marketers and coaching staff through every decision."
+    },
+    "landing_journey_step1_title": {
+        "it": "Definisci il tuo format",
+        "en": "Define your format"
+    },
+    "landing_journey_step1_description": {
+        "it": "Scegli gironi, eliminazione o format misti e personalizza punteggi, set e comunicazioni automatiche.",
+        "en": "Choose round robin, knockout or hybrid formats and customize scores, sets and automated communications."
+    },
+    "landing_journey_step2_title": {
+        "it": "Invita, registra, ingaggia",
+        "en": "Invite, register, engage"
+    },
+    "landing_journey_step2_description": {
+        "it": "Condividi la lobby con i giocatori, raccogli iscrizioni e crea hype con notifiche e contenuti visual.",
+        "en": "Share the lobby with players, collect registrations and build hype with notifications and visual content."
+    },
+    "landing_journey_step3_title": {
+        "it": "Monitora e racconta",
+        "en": "Monitor and tell the story"
+    },
+    "landing_journey_step3_description": {
+        "it": "Risultati live, leaderboard dinamiche e report pronti per sponsor, social e partner media.",
+        "en": "Live results, dynamic leaderboards and reports ready for sponsors, social and media partners."
+    },
+    "landing_journey_primary_cta": {
+        "it": "Apri il tuo torneo",
+        "en": "Launch your tournament"
+    },
+    "landing_journey_secondary_cta": {
+        "it": "Prova la demo live",
+        "en": "Try the live demo"
+    },
+    "landing_journey_insight_title": {
+        "it": "Insight in tempo reale",
+        "en": "Real-time insight"
+    },
+    "landing_journey_insight_metric_label": {
+        "it": "Player spotlight",
+        "en": "Player spotlight"
+    },
+    "landing_journey_insight_metric_value": {
+        "it": "+22% rally vinti",
+        "en": "+22% rallies won"
+    },
+    "landing_journey_insight_cta": {
+        "it": "Accedi alle analytics",
+        "en": "Access analytics"
+    },
+    "landing_testimonials_title": {
+        "it": "Club e coach parlano di noi",
+        "en": "Clubs and coaches talk about us"
+    },
+    "landing_testimonials_subtitle": {
+        "it": "Design e performance pensati per chi vive di match point. Fidati di chi ha già cambiato il modo di gestire i tornei.",
+        "en": "Design and performance tailored for those who live for match point. Trust those who already changed how they run tournaments."
+    },
+    "landing_testimonial_1_quote": {
+        "it": "«Abbiamo ridotto del 60% il tempo speso a organizzare tornei weekend grazie a Pong Smash Board.»",
+        "en": "“We cut the time spent organizing weekend tournaments by 60% thanks to Pong Smash Board.”"
+    },
+    "landing_testimonial_1_name": {
+        "it": "Martina L.",
+        "en": "Martina L."
+    },
+    "landing_testimonial_1_role": {
+        "it": "Founder, Ping Pong Club Milano",
+        "en": "Founder, Ping Pong Club Milan"
+    },
+    "landing_testimonial_2_quote": {
+        "it": "«Statistiche live, ranking automatici e zero fogli Excel: finalmente posso concentrarmi sui giocatori.»",
+        "en": "“Live stats, automatic rankings and zero spreadsheets: I can finally focus on the players.”"
+    },
+    "landing_testimonial_2_name": {
+        "it": "Luca P.",
+        "en": "Luca P."
+    },
+    "landing_testimonial_2_role": {
+        "it": "Coach Professionista",
+        "en": "Professional coach"
+    },
+    "landing_testimonials_cta_title": {
+        "it": "Pronto a trasformare la tua prossima competizione?",
+        "en": "Ready to transform your next competition?"
+    },
+    "landing_testimonials_cta_subtitle": {
+        "it": "Crea un account gratuito e inizia a costruire un'esperienza memorabile per giocatori e pubblico.",
+        "en": "Create a free account and start building a memorable experience for players and fans."
+    },
+    "landing_testimonials_cta_button": {
+        "it": "Crea account gratuito",
+        "en": "Create free account"
+    },
+    "landing_faq_title": {
+        "it": "Perché funziona per marketing, staff tecnico e sponsor",
+        "en": "Why it works for marketing, coaching staff and sponsors"
+    },
+    "landing_faq_subtitle": {
+        "it": "Workflow condivisi, notifiche smart e KPI chiari trasformano ogni torneo in un'occasione di crescita per la tua community.",
+        "en": "Shared workflows, smart notifications and clear KPIs turn every tournament into a growth opportunity for your community."
+    },
+    "landing_faq_stat1_label": {
+        "it": "di soddisfazione organizzatori",
+        "en": "organizer satisfaction"
+    },
+    "landing_faq_stat2_label": {
+        "it": "engagement sponsor",
+        "en": "sponsor engagement"
+    },
+    "landing_faq_stat3_label": {
+        "it": "supporto dedicato",
+        "en": "dedicated support"
+    },
+    "landing_faq_q1": {
+        "it": "Posso personalizzare il brand della competizione?",
+        "en": "Can I customize the competition branding?"
+    },
+    "landing_faq_a1": {
+        "it": "Certo, puoi impostare palette, loghi e contenuti editoriali per ogni torneo così da comunicare in modo coerente con sponsor e partner.",
+        "en": "Absolutely. Configure palettes, logos and editorial content for every tournament to communicate consistently with sponsors and partners."
+    },
+    "landing_faq_q2": {
+        "it": "È previsto un supporto per l'onboarding del team?",
+        "en": "Do you provide onboarding support for the team?"
+    },
+    "landing_faq_a2": {
+        "it": "Il nostro team Customer Success ti accompagna nella configurazione iniziale e offre sessioni di formazione per arbitri, staff marketing e allenatori.",
+        "en": "Our Customer Success team supports your initial setup and delivers training sessions for referees, marketing staff and coaches."
+    },
+    "landing_faq_q3": {
+        "it": "Posso integrare Pong Smash Board con altri strumenti?",
+        "en": "Can I integrate Pong Smash Board with other tools?"
+    },
+    "landing_faq_a3": {
+        "it": "Sì, l'API aperta permette di collegare CRM, piattaforme newsletter e digital signage per esperienze multicanale impeccabili.",
+        "en": "Yes. The open API lets you connect CRMs, newsletter platforms and digital signage for seamless multichannel experiences."
+    },
+    "landing_faq_cta_primary": {
+        "it": "Accedi alla piattaforma",
+        "en": "Log into the platform"
+    },
+    "landing_faq_cta_secondary": {
+        "it": "Richiedi una demo guidata",
+        "en": "Request a guided demo"
     }
 
 }

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -5,11 +5,13 @@ import { CallbackComponent } from './auth/callback/callback.component';
 import { LoginComponent } from './auth/login/login.component';
 import { FlowGuard } from './auth/guards/flow.guard';
 import { HomeComponent } from './components/home.component';
+import { LandingComponent } from './components/landing/landing.component';
 import { CompetitionsComponent } from './components/competitions/competitions/competitions.component';
 import { ProfileComponent } from './components/profile/profile/profile.component';
 import { CompleteProfileComponent } from './components/profile/complete-profile/complete-profile.component';
 
 export const routes: Routes = [
+  { path: '', component: LandingComponent },
   { path: 'home-page', component: HomeComponent, canActivate: [AuthGuard, FlowGuard] },
   { path: 'login', component: LoginComponent },
   { path: 'register', component: RegisterComponent },
@@ -17,5 +19,5 @@ export const routes: Routes = [
   { path: 'profile', component: ProfileComponent, canActivate: [AuthGuard, FlowGuard] },
   { path: 'complete-profile', component: CompleteProfileComponent, canActivate: [AuthGuard] },
   { path: 'competitions', component: CompetitionsComponent, canActivate: [AuthGuard] },
-  { path: '**', redirectTo: 'home-page', pathMatch: 'full' }
+  { path: '**', redirectTo: '', pathMatch: 'full' }
 ];

--- a/src/app/components/landing/landing.component.html
+++ b/src/app/components/landing/landing.component.html
@@ -1,0 +1,262 @@
+<section class="landing-hero text-center text-md-start">
+  <div class="container position-relative">
+    <div class="row align-items-center">
+      <div class="col-md-7">
+        <span class="badge rounded-pill text-uppercase tracking">{{ 'landing_hero_badge' | translate }}</span>
+        <h1 class="display-4 fw-bold mt-3">
+          {{ 'landing_hero_title_prefix' | translate }} <span class="gradient-text">Pong Smash Board</span>
+        </h1>
+        <p class="lead mt-4">
+          {{ 'landing_hero_lead' | translate }}
+        </p>
+        <div class="cta-group d-flex flex-column flex-sm-row gap-3 mt-4">
+          <a routerLink="/register" class="btn btn-primary btn-lg px-4 shadow-lg">{{ 'landing_hero_cta_primary' | translate }}</a>
+          <a routerLink="/login" class="btn btn-outline-light btn-lg px-4">{{ 'landing_hero_cta_secondary' | translate }}</a>
+          <a href="#features" class="btn btn-link text-decoration-none">{{ 'landing_hero_cta_tertiary' | translate }}</a>
+        </div>
+        <div class="social-proof mt-5 d-flex align-items-center gap-3 flex-wrap">
+          <div class="avatars d-flex align-items-center">
+            <span class="avatar"></span>
+            <span class="avatar"></span>
+            <span class="avatar"></span>
+          </div>
+          <p class="m-0 small opacity-75">{{ 'landing_hero_social_proof' | translate }}</p>
+        </div>
+      </div>
+      <div class="col-md-5 mt-5 mt-md-0">
+        <div class="preview-card shadow-lg">
+          <div class="preview-header d-flex justify-content-between align-items-center">
+            <span class="fw-semibold">{{ 'landing_preview_title' | translate }}</span>
+            <span class="badge bg-gradient">{{ 'landing_preview_status' | translate }}</span>
+          </div>
+          <div class="preview-body mt-4">
+            <div class="match d-flex justify-content-between align-items-center">
+              <div>
+                <h4>{{ 'landing_preview_team_one' | translate }}</h4>
+                <span>{{ 'landing_preview_ranking_one' | translate }}</span>
+              </div>
+              <div class="score">3</div>
+            </div>
+            <div class="match d-flex justify-content-between align-items-center">
+              <div>
+                <h4>{{ 'landing_preview_team_two' | translate }}</h4>
+                <span>{{ 'landing_preview_ranking_two' | translate }}</span>
+              </div>
+              <div class="score muted">2</div>
+            </div>
+            <div class="progress-wrapper mt-4">
+              <div class="progress">
+                <div class="progress-bar" role="progressbar" style="width: 68%"></div>
+              </div>
+              <small class="mt-2 d-block text-uppercase">{{ 'landing_preview_progress' | translate }}</small>
+            </div>
+          </div>
+          <div class="preview-footer mt-4 d-flex justify-content-between align-items-center">
+            <div>
+              <span class="d-block text-uppercase small">{{ 'landing_preview_footer_label' | translate }}</span>
+              <span class="highlight">{{ 'landing_preview_footer_highlight' | translate }}</span>
+            </div>
+            <a routerLink="/login" class="btn btn-sm btn-primary rounded-pill">{{ 'landing_preview_footer_cta' | translate }}</a>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="floating-card card-one"></div>
+    <div class="floating-card card-two"></div>
+  </div>
+</section>
+
+<section id="features" class="landing-features py-5">
+  <div class="container">
+    <div class="row text-center">
+      <div class="col-lg-8 mx-auto">
+        <h2 class="fw-bold">{{ 'landing_features_title' | translate }}</h2>
+        <p class="mt-3">
+          {{ 'landing_features_subtitle' | translate }}
+        </p>
+      </div>
+    </div>
+    <div class="row mt-5 g-4">
+      <div class="col-md-4" *ngFor="let item of highlights">
+        <div class="feature-tile h-100 p-4">
+          <div class="icon-wrapper">
+            <i [ngClass]="['fa', item.icon]"></i>
+          </div>
+          <h3 class="h5 mt-3">{{ item.titleKey | translate }}</h3>
+          <p class="opacity-75">{{ item.descriptionKey | translate }}</p>
+          <a routerLink="/register" class="stretched-link">{{ 'landing_features_highlight_cta' | translate }}</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="how-it-works" class="landing-journey py-5">
+  <div class="container">
+    <div class="row align-items-center gy-5">
+      <div class="col-lg-6">
+        <h2 class="fw-bold">{{ 'landing_journey_title' | translate }}</h2>
+        <p class="mt-3">
+          {{ 'landing_journey_subtitle' | translate }}
+        </p>
+        <ul class="timeline list-unstyled mt-4">
+          <li>
+            <span class="timeline-index">01</span>
+            <div>
+              <h4>{{ 'landing_journey_step1_title' | translate }}</h4>
+              <p>{{ 'landing_journey_step1_description' | translate }}</p>
+            </div>
+          </li>
+          <li>
+            <span class="timeline-index">02</span>
+            <div>
+              <h4>{{ 'landing_journey_step2_title' | translate }}</h4>
+              <p>{{ 'landing_journey_step2_description' | translate }}</p>
+            </div>
+          </li>
+          <li>
+            <span class="timeline-index">03</span>
+            <div>
+              <h4>{{ 'landing_journey_step3_title' | translate }}</h4>
+              <p>{{ 'landing_journey_step3_description' | translate }}</p>
+            </div>
+          </li>
+        </ul>
+        <div class="d-flex flex-wrap gap-3 mt-4">
+          <a routerLink="/register" class="btn btn-primary">{{ 'landing_journey_primary_cta' | translate }}</a>
+          <a routerLink="/login" class="btn btn-outline-light">{{ 'landing_journey_secondary_cta' | translate }}</a>
+        </div>
+      </div>
+      <div class="col-lg-6">
+        <div class="insight-card">
+          <h5 class="text-uppercase small">{{ 'landing_journey_insight_title' | translate }}</h5>
+          <div class="chart-placeholder mt-4">
+            <div class="bar bar-1"></div>
+            <div class="bar bar-2"></div>
+            <div class="bar bar-3"></div>
+            <div class="bar bar-4"></div>
+          </div>
+          <div class="mt-4 d-flex justify-content-between align-items-center">
+            <div>
+              <span class="d-block text-uppercase small">{{ 'landing_journey_insight_metric_label' | translate }}</span>
+              <strong>{{ 'landing_journey_insight_metric_value' | translate }}</strong>
+            </div>
+            <a routerLink="/login" class="btn btn-sm btn-contrast">{{ 'landing_journey_insight_cta' | translate }}</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="landing-testimonials py-5">
+  <div class="container">
+    <div class="row text-center">
+      <div class="col-lg-8 mx-auto">
+        <h2 class="fw-bold">{{ 'landing_testimonials_title' | translate }}</h2>
+        <p class="mt-3 opacity-75">
+          {{ 'landing_testimonials_subtitle' | translate }}
+        </p>
+      </div>
+    </div>
+    <div class="row mt-5 g-4">
+      <div class="col-md-6" *ngFor="let testimonial of testimonials">
+        <div class="testimonial p-4 h-100">
+          <p class="mb-4">{{ testimonial.quoteKey | translate }}</p>
+          <div>
+            <span class="fw-semibold">{{ testimonial.nameKey | translate }}</span>
+            <span class="d-block small opacity-75">{{ testimonial.roleKey | translate }}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="cta-panel mt-5 p-4 p-md-5 text-center text-md-start">
+      <div class="row align-items-center gy-3">
+        <div class="col-md-8">
+          <h3 class="fw-bold">{{ 'landing_testimonials_cta_title' | translate }}</h3>
+          <p class="m-0">{{ 'landing_testimonials_cta_subtitle' | translate }}</p>
+        </div>
+        <div class="col-md-4 text-md-end">
+          <a routerLink="/register" class="btn btn-light btn-lg text-dark">{{ 'landing_testimonials_cta_button' | translate }}</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="landing-faq py-5">
+  <div class="container">
+    <div class="row align-items-center gy-4">
+      <div class="col-lg-6">
+        <h2 class="fw-bold">{{ 'landing_faq_title' | translate }}</h2>
+        <p class="mt-3">
+          {{ 'landing_faq_subtitle' | translate }}
+        </p>
+        <div class="stats-grid mt-4">
+          <div class="stat">
+            <span class="value">98%</span>
+            <span class="label">{{ 'landing_faq_stat1_label' | translate }}</span>
+          </div>
+          <div class="stat">
+            <span class="value">2x</span>
+            <span class="label">{{ 'landing_faq_stat2_label' | translate }}</span>
+          </div>
+          <div class="stat">
+            <span class="value">24/7</span>
+            <span class="label">{{ 'landing_faq_stat3_label' | translate }}</span>
+          </div>
+        </div>
+      </div>
+      <div class="col-lg-6">
+        <div class="accordion" id="landingAccordion">
+          <div class="accordion-item">
+            <h2 class="accordion-header" id="headingOne">
+              <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseOne"
+                aria-expanded="true" aria-controls="collapseOne">
+                {{ 'landing_faq_q1' | translate }}
+              </button>
+            </h2>
+            <div id="collapseOne" class="accordion-collapse collapse show" aria-labelledby="headingOne"
+              data-bs-parent="#landingAccordion">
+              <div class="accordion-body">
+                {{ 'landing_faq_a1' | translate }}
+              </div>
+            </div>
+          </div>
+          <div class="accordion-item">
+            <h2 class="accordion-header" id="headingTwo">
+              <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseTwo"
+                aria-expanded="false" aria-controls="collapseTwo">
+                {{ 'landing_faq_q2' | translate }}
+              </button>
+            </h2>
+            <div id="collapseTwo" class="accordion-collapse collapse" aria-labelledby="headingTwo"
+              data-bs-parent="#landingAccordion">
+              <div class="accordion-body">
+                {{ 'landing_faq_a2' | translate }}
+              </div>
+            </div>
+          </div>
+          <div class="accordion-item">
+            <h2 class="accordion-header" id="headingThree">
+              <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseThree"
+                aria-expanded="false" aria-controls="collapseThree">
+                {{ 'landing_faq_q3' | translate }}
+              </button>
+            </h2>
+            <div id="collapseThree" class="accordion-collapse collapse" aria-labelledby="headingThree"
+              data-bs-parent="#landingAccordion">
+              <div class="accordion-body">
+                {{ 'landing_faq_a3' | translate }}
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="mt-4 text-center text-lg-start">
+          <a routerLink="/login" class="btn btn-primary me-lg-3">{{ 'landing_faq_cta_primary' | translate }}</a>
+          <a routerLink="/register" class="btn btn-outline-light">{{ 'landing_faq_cta_secondary' | translate }}</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/app/components/landing/landing.component.scss
+++ b/src/app/components/landing/landing.component.scss
@@ -1,0 +1,353 @@
+:host {
+  display: block;
+  color: var(--primary-ultra-light);
+  background: var(--gradient-reverse);
+}
+
+section {
+  position: relative;
+  overflow: hidden;
+}
+
+.landing-hero {
+  padding: clamp(4rem, 8vw, 8rem) 0;
+  background: radial-gradient(circle at top left, rgba(40, 74, 166, 0.45), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(199, 99, 96, 0.35), transparent 50%),
+    var(--gradient);
+}
+
+.badge.tracking {
+  background: rgba(40, 74, 166, 0.2);
+  color: var(--primary-light);
+  letter-spacing: 0.2em;
+  font-weight: 600;
+  padding: 0.6rem 1.5rem;
+}
+
+.gradient-text {
+  background: linear-gradient(90deg, var(--primary-light), var(--contrast));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.cta-group .btn {
+  border-radius: var(--border-radius);
+  font-weight: 600;
+}
+
+.cta-group .btn-link {
+  color: var(--primary-light);
+  font-weight: 600;
+  padding-inline: 0;
+}
+
+%glass-panel {
+  border-radius: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(9, 22, 34, 0.8);
+  backdrop-filter: blur(10px);
+  color: var(--primary-ultra-light);
+}
+
+.social-proof .avatar {
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.15);
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  margin-left: -0.9rem;
+  animation: pulse 3s infinite;
+}
+
+.social-proof .avatar:first-child {
+  margin-left: 0;
+}
+
+.preview-card {
+  @extend %glass-panel;
+  background: rgba(9, 22, 34, 0.85);
+  padding: 2rem;
+  position: relative;
+  z-index: 1;
+}
+
+.preview-header .badge {
+  background: linear-gradient(120deg, var(--contrast), var(--primary));
+  color: #fff;
+  padding: 0.4rem 1rem;
+}
+
+.preview-body .match {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 1rem;
+  padding: 1rem 1.5rem;
+  margin-bottom: 1rem;
+  transition: transform 0.3s ease;
+}
+
+.preview-body .match:hover {
+  transform: translateY(-4px);
+}
+
+.preview-body h4 {
+  margin: 0;
+}
+
+.preview-body span {
+  font-size: 0.875rem;
+  opacity: 0.65;
+}
+
+.preview-body .score {
+  font-size: 2.25rem;
+  font-weight: 700;
+  color: var(--primary-light);
+}
+
+.preview-body .score.muted {
+  color: rgba(255, 255, 255, 0.4);
+}
+
+.progress-wrapper .progress {
+  height: 0.6rem;
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.progress-bar {
+  background: linear-gradient(90deg, var(--primary-light), var(--contrast));
+}
+
+.preview-footer .highlight {
+  color: var(--primary-light);
+  font-weight: 600;
+}
+
+.preview-footer .btn-primary {
+  border-radius: 999px;
+  padding-inline: 1.5rem;
+}
+
+.floating-card {
+  position: absolute;
+  width: clamp(8rem, 15vw, 12rem);
+  height: clamp(8rem, 15vw, 12rem);
+  border-radius: 50%;
+  background: rgba(64, 55, 135, 0.2);
+  backdrop-filter: blur(8px);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  animation: float 12s ease-in-out infinite;
+  z-index: 0;
+}
+
+.floating-card.card-one {
+  top: 5%;
+  right: 8%;
+}
+
+.floating-card.card-two {
+  bottom: 10%;
+  left: -3%;
+  animation-delay: -3s;
+}
+
+.landing-features {
+  background: var(--dark);
+}
+
+.landing-features h2 {
+  color: #fff;
+}
+
+.feature-tile {
+  @extend %glass-panel;
+  background: rgba(5, 19, 28, 0.75);
+  transition: transform 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.feature-tile:hover {
+  transform: translateY(-8px);
+  border-color: rgba(110, 150, 255, 0.6);
+  box-shadow: 0 1.5rem 3rem -1.5rem rgba(40, 74, 166, 0.7);
+}
+
+.feature-tile .icon-wrapper {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3.5rem;
+  height: 3.5rem;
+  border-radius: 1rem;
+  background: rgba(40, 74, 166, 0.15);
+  color: var(--primary-light);
+  font-size: 1.75rem;
+}
+
+.feature-tile .stretched-link {
+  color: var(--primary-light);
+  font-weight: 600;
+}
+
+.landing-journey {
+  background: linear-gradient(180deg, rgba(5, 19, 28, 0.9), rgba(2, 11, 18, 0.95));
+}
+
+.timeline li {
+  display: flex;
+  gap: 1.25rem;
+  margin-bottom: 1.5rem;
+  align-items: flex-start;
+}
+
+.timeline-index {
+  flex-shrink: 0;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 1rem;
+  display: grid;
+  place-items: center;
+  background: rgba(110, 150, 255, 0.1);
+  color: var(--primary-light);
+  font-weight: 700;
+}
+
+.timeline p {
+  margin-bottom: 0;
+  opacity: 0.75;
+}
+
+.insight-card {
+  @extend %glass-panel;
+  background: rgba(9, 22, 34, 0.85);
+  border-radius: 1.75rem;
+  padding: 2.5rem;
+  border-color: rgba(255, 255, 255, 0.06);
+  box-shadow: 0 2rem 4rem -2rem rgba(8, 24, 36, 0.95);
+}
+
+.chart-placeholder {
+  display: flex;
+  align-items: flex-end;
+  gap: 1.25rem;
+  height: 12rem;
+}
+
+.chart-placeholder .bar {
+  flex: 1;
+  border-radius: 1rem 1rem 0 0;
+  background: linear-gradient(180deg, rgba(110, 150, 255, 0.7), rgba(40, 74, 166, 0.4));
+  animation: grow 4s ease-in-out infinite;
+  transform-origin: bottom;
+}
+
+.chart-placeholder .bar-2 {
+  height: 70%;
+  animation-delay: -1s;
+}
+
+.chart-placeholder .bar-3 {
+  height: 90%;
+  animation-delay: -2s;
+}
+
+.chart-placeholder .bar-4 {
+  height: 55%;
+  animation-delay: -3s;
+}
+
+.btn-contrast {
+  background: var(--contrast);
+  color: #fff;
+  border-radius: 999px;
+  padding-inline: 1.75rem;
+  font-weight: 600;
+}
+
+.landing-testimonials {
+  background: var(--gradient-reverse);
+}
+
+.testimonial {
+  @extend %glass-panel;
+  background: rgba(255, 255, 255, 0.05);
+  position: relative;
+}
+
+.testimonial::before {
+  content: '\201C';
+  position: absolute;
+  top: -0.7rem;
+  left: 1.2rem;
+  font-size: 6rem;
+  color: rgba(110, 150, 255, 0.15);
+}
+
+.cta-panel {
+  background: linear-gradient(120deg, rgba(40, 74, 166, 0.6), rgba(199, 99, 96, 0.6));
+  border-radius: 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 1.5rem 3rem -2rem rgba(0, 0, 0, 0.7);
+}
+
+.landing-faq {
+  background: rgba(2, 11, 18, 0.96);
+}
+
+@keyframes float {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+
+  50% {
+    transform: translate3d(0, -15px, 0) scale(1.05);
+  }
+}
+
+@keyframes grow {
+  0%,
+  100% {
+    transform: scaleY(0.85);
+  }
+
+  50% {
+    transform: scaleY(1);
+  }
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+
+  50% {
+    transform: scale(1.05);
+    opacity: 0.8;
+  }
+}
+
+@media (max-width: 992px) {
+  .preview-card {
+    margin-inline: auto;
+  }
+
+  .cta-panel {
+    text-align: center;
+  }
+}
+
+@media (max-width: 768px) {
+  .landing-hero {
+    text-align: center;
+  }
+
+  .cta-group {
+    align-items: center;
+  }
+
+  .floating-card.card-two {
+    display: none;
+  }
+}
+

--- a/src/app/components/landing/landing.component.ts
+++ b/src/app/components/landing/landing.component.ts
@@ -1,0 +1,56 @@
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { CommonModule } from '@angular/common';
+import { TranslatePipe } from '../../utils/translate.pipe';
+
+interface LandingHighlight {
+  titleKey: string;
+  descriptionKey: string;
+  icon: string;
+}
+
+interface Testimonial {
+  quoteKey: string;
+  nameKey: string;
+  roleKey: string;
+}
+
+@Component({
+  selector: 'app-landing',
+  standalone: true,
+  imports: [CommonModule, RouterLink, TranslatePipe],
+  templateUrl: './landing.component.html',
+  styleUrl: './landing.component.scss'
+})
+export class LandingComponent {
+  readonly highlights: LandingHighlight[] = [
+    {
+      titleKey: 'landing_highlight_management_title',
+      descriptionKey: 'landing_highlight_management_description',
+      icon: 'fa-trophy'
+    },
+    {
+      titleKey: 'landing_highlight_tracking_title',
+      descriptionKey: 'landing_highlight_tracking_description',
+      icon: 'fa-bolt'
+    },
+    {
+      titleKey: 'landing_highlight_insights_title',
+      descriptionKey: 'landing_highlight_insights_description',
+      icon: 'fa-line-chart'
+    }
+  ];
+
+  readonly testimonials: Testimonial[] = [
+    {
+      quoteKey: 'landing_testimonial_1_quote',
+      nameKey: 'landing_testimonial_1_name',
+      roleKey: 'landing_testimonial_1_role'
+    },
+    {
+      quoteKey: 'landing_testimonial_2_quote',
+      nameKey: 'landing_testimonial_2_name',
+      roleKey: 'landing_testimonial_2_role'
+    }
+  ];
+}

--- a/src/style/landing.scss
+++ b/src/style/landing.scss
@@ -1,0 +1,68 @@
+app-landing {
+  .stats-grid {
+    display: grid;
+    gap: 1.25rem;
+    grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+  }
+
+  .stat {
+    border-radius: 1.5rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: rgba(255, 255, 255, 0.06);
+    backdrop-filter: blur(10px);
+    color: var(--primary-ultra-light);
+    padding: 1.5rem;
+    text-align: center;
+  }
+
+  .stat .value {
+    display: block;
+    font-size: 2rem;
+    font-weight: 700;
+    color: var(--primary-light);
+  }
+
+  .stat .label {
+    font-size: 0.875rem;
+    opacity: 0.7;
+  }
+
+  .accordion-item {
+    background: rgba(5, 19, 28, 0.8);
+    border: none;
+  }
+
+  .accordion-button {
+    background: transparent;
+    color: var(--primary-ultra-light);
+    font-weight: 600;
+  }
+
+  .accordion-button:not(.collapsed) {
+    color: var(--primary-light);
+    box-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.08);
+  }
+
+  .accordion-body {
+    color: rgba(255, 255, 255, 0.8);
+  }
+
+  .btn-outline-light {
+    border-color: rgba(255, 255, 255, 0.3);
+    color: var(--primary-ultra-light);
+  }
+
+  .btn-outline-light:hover {
+    background: rgba(255, 255, 255, 0.1);
+    color: #fff;
+  }
+
+  .btn-primary {
+    background: linear-gradient(120deg, var(--primary), var(--primary-light));
+    border: none;
+  }
+
+  .btn-primary:hover {
+    filter: brightness(1.05);
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -4,6 +4,7 @@
 @use "style/slider.scss";
 @use "style/utility.scss";
 @use "style/forms.scss";
+@use "style/landing.scss";
 
 * {
     box-sizing: border-box;


### PR DESCRIPTION
## Summary
- add a standalone marketing-focused landing component with hero, feature highlights, journey, testimonials, faq and multiple calls-to-action
- style the landing experience with animated gradients, glassmorphism cards and responsive bootstrap layout while reusing theme variables
- expose the landing page at the root route and share supporting styles through a global SCSS module
- localize every landing page label through lang.json entries and the translate pipe for full i18n support

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d468ef12988322a06afa8ed8ddb984