### PR TITLE
refactor: redesign dropdown for mobile usability

### DIFF
--- a/src/app/common/dropdown/dropdown.component.html
+++ b/src/app/common/dropdown/dropdown.component.html
@@ -1,15 +1,48 @@
-<div class="relative inline-block text-left">
-    <!-- Dots button -->
-    <button class="dots" (click)="toggle()" *ngIf="!isOpen">...</button>
+<div class="dropdown" [class.dropdown--open]="isOpen">
+  <button
+    #triggerButton
+    type="button"
+    class="dropdown__trigger"
+    (click)="onToggleClick()"
+    (keydown)="onTriggerKeydown($event)"
+    [attr.aria-expanded]="isOpen"
+    aria-haspopup="true"
+    [attr.aria-controls]="isOpen ? menuId : null"
+  >
+    <span class="sr-only">Apri il menu delle azioni</span>
+    <span aria-hidden="true" class="dropdown__trigger-dots">
+      <span></span>
+      <span></span>
+      <span></span>
+    </span>
+  </button>
 
-    <!-- Dropdown menu -->
-    <div *ngIf="isOpen" class="dropdown-dots d-flex flex-column">
-        <button *ngFor="let a of actions" (click)="select(a.value)"
-            [style]="a.value === 'delete' ? 'color: var(--contrast);' : ''">
-            <div class="d-flex justify-content-left" style="gap: 0.625em;">
-                <span *ngIf="a.icon" [innerHTML]="a.icon"></span>
-                 {{ a.label }}
-            </div>
-        </button>
-    </div>
+  <div
+    class="dropdown__backdrop"
+    *ngIf="isOpen"
+    (click)="close(true)"
+    aria-hidden="true"
+  ></div>
+
+  <div
+    #menu
+    *ngIf="isOpen"
+    class="dropdown__menu"
+    role="menu"
+    [attr.id]="menuId"
+  >
+    <button
+      #menuButton
+      *ngFor="let a of actions; trackBy: trackByValue"
+      type="button"
+      class="dropdown__item"
+      role="menuitem"
+      (click)="select(a.value)"
+      (keydown)="onItemKeydown($event, a.value)"
+      [class.dropdown__item--danger]="a.value === 'delete'"
+    >
+      <span *ngIf="a.icon" class="dropdown__icon" [innerHTML]="a.icon"></span>
+      <span class="dropdown__label">{{ a.label }}</span>
+    </button>
+  </div>
 </div>

--- a/src/app/common/dropdown/dropdown.component.scss
+++ b/src/app/common/dropdown/dropdown.component.scss
@@ -1,51 +1,172 @@
-.dots {
-    all: unset;
-    font-size: 1.2em;
-    cursor: pointer;
-    display: inline-block;
-    transition: transform 0.25s ease-in-out, opacity 0.25s ease-in-out;
-    padding: 0.5em;
-
-    &:hover {
-        transform: scale(0.9);
-        opacity: 0.8;
-    }
-
-    position: absolute;
-    bottom: 0;
-    right: 0;
+:host {
+  position: relative;
+  display: inline-flex;
 }
 
-.relative {
-    position: relative;
-    z-index: auto;
+.dropdown {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
-.dropdown-dots {
-    position: relative;
-    top: 100%;
-    right: 0;
-    background: #1f2937;
+.dropdown__trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 9999px;
+  border: none;
+  background: linear-gradient(145deg, rgba(30, 41, 59, 0.95), rgba(15, 23, 42, 0.95));
+  color: var(--white, #f8fafc);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  padding: 0;
+}
+
+.dropdown__trigger:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.35);
+}
+
+.dropdown__trigger:active {
+  transform: translateY(0);
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.3);
+}
+
+.dropdown__trigger:focus-visible {
+  outline: 3px solid rgba(59, 130, 246, 0.65);
+  outline-offset: 3px;
+}
+
+.dropdown__trigger-dots {
+  display: inline-grid;
+  grid-template-columns: repeat(3, auto);
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.dropdown__trigger-dots span {
+  display: block;
+  width: 0.35rem;
+  height: 0.35rem;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.9;
+}
+
+.dropdown__backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.25);
+  backdrop-filter: blur(2px);
+  z-index: 10;
+}
+
+.dropdown__menu {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  right: 0;
+  min-width: 11rem;
+  padding: 0.5rem;
+  background: linear-gradient(165deg, rgba(15, 23, 42, 0.98), rgba(30, 41, 59, 0.92));
+  border-radius: 0.9rem;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  z-index: 20;
+  animation: dropdownFade 0.18s ease-out;
+}
+
+.dropdown__item {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  border: none;
+  border-radius: 0.65rem;
+  background: transparent;
+  color: var(--white, #f8fafc);
+  font-size: 0.95rem;
+  font-weight: 500;
+  padding: 0.6rem 0.75rem;
+  transition: background 0.18s ease, color 0.18s ease, transform 0.18s ease;
+  cursor: pointer;
+  text-align: left;
+}
+
+.dropdown__item:hover,
+.dropdown__item:focus-visible {
+  background: rgba(59, 130, 246, 0.18);
+  color: #e2e8f0;
+  transform: translateX(2px);
+  outline: none;
+}
+
+.dropdown__item:active {
+  transform: translateX(0);
+}
+
+.dropdown__item--danger {
+  color: var(--contrast, #f87171);
+}
+
+.dropdown__item--danger:hover,
+.dropdown__item--danger:focus-visible {
+  background: rgba(248, 113, 113, 0.14);
+  color: #fecaca;
+}
+
+.dropdown__icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  height: 1.25rem;
+  color: inherit;
+}
+
+.dropdown__label {
+  flex: 1;
+  white-space: nowrap;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 640px) {
+  .dropdown__backdrop {
+    display: block;
+  }
+
+  .dropdown__menu {
+    min-width: clamp(12rem, 80vw, 18rem);
+    border-radius: 1rem;
+    padding: 0.75rem;
+  }
+}
+
+.dropdown--open .dropdown__trigger {
+  background: linear-gradient(145deg, rgba(37, 99, 235, 0.95), rgba(59, 130, 246, 0.9));
+}
+
+@keyframes dropdownFade {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+  to {
     opacity: 1;
-    /* grigio scuro */
-    color: white;
-    border-radius: 0.5rem;
-    padding: 0.25rem;
-    box-shadow: 0em 0.25em 0.5em rgba(0, 0, 0, 0.2);
-    display: flex;
-    flex-direction: column;
-    min-width: 7.5em;
-    z-index: 2;
-}
-
-button {
-    all: unset;
-    background: transparent;
-    border: none;
-    text-align: left;
-    padding: 0.5rem 0.75rem;
-    cursor: pointer;
-    color: white;
-    font-size: 0.875rem;
-
+    transform: translateY(0);
+  }
 }

--- a/src/app/common/dropdown/dropdown.component.ts
+++ b/src/app/common/dropdown/dropdown.component.ts
@@ -1,4 +1,14 @@
-import { Component, EventEmitter, Input, Output, ViewEncapsulation } from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  EventEmitter,
+  HostListener,
+  Input,
+  Output,
+  QueryList,
+  ViewChild,
+  ViewChildren,
+} from '@angular/core';
 import { SHARED_IMPORTS } from '../imports/shared.imports';
 
 export interface DropdownAction {
@@ -15,37 +25,158 @@ export interface DropdownAction {
 })
 
 export class DropdownComponent {
+  private static nextId = 0;
+
   @Input() actions: DropdownAction[] = [];
   @Output() actionSelected = new EventEmitter<string>();
 
   isOpen = false;
+  readonly menuId = `app-dropdown-menu-${DropdownComponent.nextId++}`;
+
+  @ViewChild('triggerButton') triggerButton?: ElementRef<HTMLButtonElement>;
+  @ViewChildren('menuButton') menuButtons?: QueryList<ElementRef<HTMLButtonElement>>;
+
+  constructor(private readonly hostElement: ElementRef<HTMLElement>) {}
 
   toggle() {
     this.isOpen = !this.isOpen;
+    if (this.isOpen) {
+      this.focusFirstItem();
+    } else {
+      this.focusTrigger();
+    }
+  }
+
+  open() {
+    if (!this.isOpen) {
+      this.isOpen = true;
+      this.focusFirstItem();
+    }
+  }
+
+  close(focusTrigger = false) {
+    if (!this.isOpen) {
+      return;
+    }
+    this.isOpen = false;
+    if (focusTrigger) {
+      this.focusTrigger();
+    }
+  }
+
+  onToggleClick() {
+    this.toggle();
+  }
+
+  onTriggerKeydown(event: KeyboardEvent) {
+    const { key } = event;
+    if (key === 'Enter' || key === ' ') {
+      event.preventDefault();
+      this.toggle();
+      return;
+    }
+
+    if (key === 'ArrowDown') {
+      event.preventDefault();
+      if (!this.isOpen) {
+        this.open();
+      }
+      this.focusFirstItem();
+    }
+
+    if (key === 'Escape' && this.isOpen) {
+      event.preventDefault();
+      this.close(true);
+    }
   }
 
   select(action: string) {
     this.actionSelected.emit(action);
-    this.isOpen = false;
+    this.close(true);
   }
 
-  // Close dropdown when clicking outside
-  constructor() { }
+  onItemKeydown(event: KeyboardEvent, value: string) {
+    const { key } = event;
+    const buttons = this.menuButtons?.toArray() ?? [];
+    const currentIndex = buttons.findIndex(
+      (btn) => btn.nativeElement === event.currentTarget
+    );
 
-  ngOnInit() { }
-
-  ngOnDestroy() {
-    document.removeEventListener('click', this.handleDocumentClick, true);
-  }
-
-  ngAfterViewInit() {
-    document.addEventListener('click', this.handleDocumentClick, true);
-  }
-
-  handleDocumentClick = (event: MouseEvent) => {
-    const dropdownElement = (event.target as HTMLElement).closest('app-dropdown');
-    if (!dropdownElement) {
-      this.isOpen = false;
+    if (key === 'Enter' || key === ' ') {
+      event.preventDefault();
+      this.select(value);
+      return;
     }
+
+    if (key === 'Escape') {
+      event.preventDefault();
+      this.close(true);
+      return;
+    }
+
+    if (key === 'ArrowDown' && buttons.length > 0) {
+      event.preventDefault();
+      const nextIndex = (currentIndex + 1) % buttons.length;
+      buttons[nextIndex]?.nativeElement.focus({ preventScroll: true });
+      return;
+    }
+
+    if (key === 'ArrowUp' && buttons.length > 0) {
+      event.preventDefault();
+      const prevIndex =
+        (currentIndex - 1 + buttons.length) % buttons.length;
+      buttons[prevIndex]?.nativeElement.focus({ preventScroll: true });
+    }
+  }
+
+  trackByValue = (_: number, action: DropdownAction) => action.value;
+
+  @HostListener('document:click', ['$event'])
+  handleDocumentClick(event: Event) {
+    this.closeIfClickOutside(event);
+  }
+
+  @HostListener('document:touchstart', ['$event'])
+  handleDocumentTouch(event: Event) {
+    this.closeIfClickOutside(event);
+  }
+
+  @HostListener('document:keydown.escape', ['$event'])
+  handleDocumentEscape(event: KeyboardEvent) {
+    if (this.isOpen) {
+      event.preventDefault();
+      this.close(true);
+    }
+  }
+
+  private closeIfClickOutside(event: Event) {
+    if (!this.isOpen) {
+      return;
+    }
+
+    const target = event.target as HTMLElement | null;
+    if (target && !this.hostElement.nativeElement.contains(target)) {
+      this.close();
+    }
+  }
+
+  private focusFirstItem() {
+    if (!this.menuButtons?.length) {
+      return;
+    }
+
+    queueMicrotask(() => {
+      this.menuButtons?.first?.nativeElement.focus({ preventScroll: true });
+    });
+  }
+
+  private focusTrigger() {
+    if (!this.triggerButton) {
+      return;
+    }
+
+    queueMicrotask(() => {
+      this.triggerButton?.nativeElement.focus({ preventScroll: true });
+    });
   }
 }


### PR DESCRIPTION
## Summary
- redesign the dropdown markup with an accessible trigger, backdrop, and menu items that expose icons and danger states
- harden the component logic by managing focus, keyboard interactions, and outside click/touch handling for iOS compatibility
- refresh the styling with a responsive gradient menu, mobile-friendly backdrop, and modern interaction feedback

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5c2efc32083229b9feb194ab9d730