### PR TITLE
Refactor home view components and add group match modal

### DIFF
--- a/src/app/common/stats/stats.component.html
+++ b/src/app/common/stats/stats.component.html
@@ -69,7 +69,7 @@
         <div class="bars">
           <div
             class="bar left player1"
-            [class.winner]="row.scored1 > row.scored2"
+            [class.winner]="row.scored1 >= row.scored2"
             [style.width.%]="barWidth(row.scored1, row.scored1 + row.scored2)">
           </div>
           <div

--- a/src/app/components/add-match-modal/add-group-match-modal/add-group-match-modal.component.html
+++ b/src/app/components/add-match-modal/add-group-match-modal/add-group-match-modal.component.html
@@ -1,0 +1,92 @@
+<app-step-indicator [activeStep]="step" [totalSteps]="totalSteps"></app-step-indicator>
+<div class="modal-content">
+  <ng-container [ngSwitch]="step">
+    <form *ngSwitchCase="1" class="form-dark" [formGroup]="groupForm" (ngSubmit)="onContinueToMatch()">
+      <label for="groupId" class="my-placeholder">{{ 'group_knockout_board_group' | translate }}</label>
+      <select id="groupId" class="my-placeholder" formControlName="groupId" required>
+        <option [ngValue]="null">{{ 'select_group' | translate }}</option>
+        <option *ngFor="let group of groups" [ngValue]="group.id">{{ group.name }}</option>
+      </select>
+      <div class="modal-buttons d-flex justify-content-end mt-4">
+        <button type="submit" class="btn btn-primary">{{ 'continue' | translate }}</button>
+      </div>
+    </form>
+
+    <form *ngSwitchCase="2" class="form-dark" [formGroup]="matchForm" (ngSubmit)="addMatch($event)">
+      <div class="selected-group" *ngIf="selectedGroup">
+        <span>{{ 'group_knockout_board_group' | translate }}: <strong>{{ selectedGroup.name }}</strong></span>
+        <button type="button" class="link" (click)="onBackToGroupSelection()">
+          {{ 'edit' | translate }}
+        </button>
+      </div>
+
+      <div>
+        <label for="date" class="my-placeholder">{{ 'date' | translate }}</label>
+        <input id="date" type="date" class="my-placeholder" formControlName="date" required>
+      </div>
+
+      <div class="row mt-3">
+        <div class="col-md-6">
+          <app-select-player [players]="getPlayers(1)" [playerNumber]="'1'" [initialPlayer]="player1"
+            (playerSelected)="setPlayer($event)">
+          </app-select-player>
+        </div>
+        <div class="col-md-6">
+          <app-select-player [players]="getPlayers(2)" [playerNumber]="'2'" [initialPlayer]="player2"
+            (playerSelected)="setPlayer($event)">
+          </app-select-player>
+        </div>
+      </div>
+
+      <div class="row mt-3">
+        <div class="info">
+          {{ 'best_of' | translate }}
+          <strong>{{ maxSets }}</strong>
+        </div>
+        <div class="col-6">
+          <input type="number" inputmode="numeric" formControlName="p1Score" min="0" max="99"
+            [placeholder]="'score1' | translate" (input)="updateContainers()" (change)="sanitizeInput('p1Score')">
+        </div>
+        <div class="col-6">
+          <input type="number" inputmode="numeric" formControlName="p2Score" min="0" max="99"
+            [placeholder]="'score2' | translate" (input)="updateContainers()" (change)="sanitizeInput('p2Score')">
+        </div>
+        <div class="text-danger" style="min-height: 1.5em;">
+          <div *ngFor="let error of errorsOfSets">{{ error | translate }}</div>
+        </div>
+      </div>
+
+      <label class="d-flex mt-4 mb-3 justify-content-center" style="max-width: 300px; margin: auto;">
+        <span style="margin-right: 1em">{{ 'Add set points' | translate }}</span>
+        <input type="checkbox" formControlName="isShowSetsPointsTrue" (change)="updateContainers()">
+      </label>
+
+      <div class="row" *ngIf="isShowSetsPointsTrue">
+        <div class="wrapper-points">
+          <div class="input-container-wrapper d-flex justify-content-center">
+            <div class="input-container" *ngFor="let set of setsPoints.controls; let i = index"
+              [formGroup]="getSetFormGroup(i)">
+              <input class="top" inputmode="numeric" type="number" formControlName="player1Points" [min]="0"
+                [max]="competition?.pointsType || maxPoints" />
+              <input class="bottom" inputmode="numeric" type="number" formControlName="player2Points" [min]="0"
+                [max]="competition?.pointsType || maxPoints" />
+            </div>
+          </div>
+        </div>
+        <div class="text-danger text-center mt-2" style="min-height: 1.5em;">
+          <div *ngFor="let error of errorsOfPoints">{{ 'Problem' | translate }}: {{ error | translate }}</div>
+        </div>
+      </div>
+
+      <div class="modal-buttons d-flex justify-content-between mt-3">
+        <button type="button" class="button-close" (click)="closeModal()">
+          {{ 'cancel' | translate }}
+        </button>
+        <button type="submit"
+          [disabled]="matchForm.invalid || errorsOfSets.length > 0 || errorsOfPoints.length > 0 || isSending">
+          {{ 'add_match' | translate }}
+        </button>
+      </div>
+    </form>
+  </ng-container>
+</div>

--- a/src/app/components/add-match-modal/add-group-match-modal/add-group-match-modal.component.scss
+++ b/src/app/components/add-match-modal/add-group-match-modal/add-group-match-modal.component.scss
@@ -1,0 +1,39 @@
+@use '../../../../style/variables.scss' as *;
+
+:host {
+  display: block;
+}
+
+.form-dark input.top {
+  margin-bottom: 0;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.form-dark input.bottom {
+  margin-bottom: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.selected-group {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+
+  .link {
+    background: none;
+    border: none;
+    color: $primary;
+    text-decoration: underline;
+    cursor: pointer;
+    padding: 0;
+  }
+}
+
+.info {
+  opacity: 0.5;
+  font-size: 0.7em;
+  margin-bottom: 5px;
+}

--- a/src/app/components/add-match-modal/add-group-match-modal/add-group-match-modal.component.ts
+++ b/src/app/components/add-match-modal/add-group-match-modal/add-group-match-modal.component.ts
@@ -1,0 +1,401 @@
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import {
+  AbstractControl,
+  FormArray,
+  FormBuilder,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { SelectPlayerComponent } from '../../../utils/components/select-player/select-player.component';
+import { TranslatePipe } from '../../../utils/translate.pipe';
+import { StepIndicatorComponent } from '../../../common/step-indicator/step-indicator.component';
+import { ModalService } from '../../../../services/modal.service';
+import { DataService } from '../../../../services/data.service';
+import { LoaderService } from '../../../../services/loader.service';
+import { TranslationService } from '../../../../services/translation.service';
+import { CompetitionService } from '../../../../services/competitions.service';
+import { ICompetition } from '../../../../api/competition.api';
+import { IPlayer } from '../../../../services/players.service';
+import { Group, mapGroupPlayerToIPlayer } from '../../../interfaces/group.interface';
+import { MSG_TYPE } from '../../../utils/enum';
+
+@Component({
+  selector: 'app-add-group-match-modal',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    SelectPlayerComponent,
+    TranslatePipe,
+    StepIndicatorComponent,
+  ],
+  templateUrl: './add-group-match-modal.component.html',
+  styleUrl: './add-group-match-modal.component.scss'
+})
+export class AddGroupMatchModalComponent implements OnInit {
+  @Output() closeModalEvent = new EventEmitter<void>();
+  @Output() openManualPointsEvent = new EventEmitter<void>();
+
+  @Input() player1: IPlayer | null = null;
+  @Input() player2: IPlayer | null = null;
+  @Input() isAlreadySelected = false;
+
+  competition: ICompetition | null = null;
+  matchForm!: FormGroup;
+  groupForm!: FormGroup;
+  groups: Group[] = [];
+  groupPlayers: IPlayer[] = [];
+  step = 1;
+  readonly totalSteps = 2;
+
+  maxSets = 5;
+  maxPoints = 11;
+  isShowSetsPointsTrue = false;
+
+  errorsOfSets: string[] = [];
+  errorsOfPoints: string[] = [];
+
+  isSending = false;
+
+  constructor(
+    private fb: FormBuilder,
+    private modalService: ModalService,
+    private dataService: DataService,
+    private loaderService: LoaderService,
+    private translateService: TranslationService,
+    private competitionService: CompetitionService,
+  ) { }
+
+  ngOnInit(): void {
+    this.initializeForms();
+
+    this.competitionService.activeCompetition$.subscribe(comp => {
+      this.competition = comp;
+      this.maxPoints = this.competition?.points_type || 11;
+      this.maxSets = this.competition?.sets_type || 5;
+      this.matchForm.get('p1Score')?.setValidators([Validators.required, Validators.min(0), Validators.max(this.maxSets)]);
+      this.matchForm.get('p2Score')?.setValidators([Validators.required, Validators.min(0), Validators.max(this.maxSets)]);
+      this.matchForm.updateValueAndValidity({ emitEvent: false });
+    });
+
+    this.dataService.groupsObs.subscribe(groups => {
+      this.groups = groups ?? [];
+      this.tryPreselectGroup();
+    });
+  }
+
+  private initializeForms() {
+    this.groupForm = this.fb.group({
+      groupId: [null, Validators.required],
+    });
+
+    this.matchForm = this.fb.group({
+      date: [new Date().toISOString().split('T')[0], Validators.required],
+      player1: [this.player1?.id, Validators.required],
+      player2: [this.player2?.id, Validators.required],
+      p1Score: [null, [Validators.required, Validators.min(0), Validators.max(this.maxSets)]],
+      p2Score: [null, [Validators.required, Validators.min(0), Validators.max(this.maxSets)]],
+      isShowSetsPointsTrue: [false],
+      setsPoints: this.fb.array([]),
+      groupId: [null, Validators.required],
+    });
+
+    this.groupForm.get('groupId')?.valueChanges.subscribe(value => {
+      if (!value) {
+        return;
+      }
+
+      this.onGroupSelected(value);
+    });
+
+    this.matchForm.get('isShowSetsPointsTrue')?.valueChanges.subscribe(() => this.updateContainers());
+    this.matchForm.get('p1Score')?.valueChanges.subscribe(() => this.sanitizeInput('p1Score'));
+    this.matchForm.get('p2Score')?.valueChanges.subscribe(() => this.sanitizeInput('p2Score'));
+  }
+
+  get setsPoints(): FormArray {
+    return this.matchForm.get('setsPoints') as FormArray;
+  }
+
+  getSetFormGroup(index: number): FormGroup {
+    return this.setsPoints.at(index) as FormGroup;
+  }
+
+  get selectedGroup(): Group | null {
+    const groupId = this.matchForm.get('groupId')?.value;
+    return this.groups.find(group => group.id === groupId) ?? null;
+  }
+
+  private tryPreselectGroup() {
+    if (!this.groups.length) {
+      return;
+    }
+
+    const selectedId = this.matchForm.get('groupId')?.value ?? this.groupForm.get('groupId')?.value;
+    if (selectedId) {
+      this.onGroupSelected(selectedId, false);
+      return;
+    }
+
+    const candidate = this.findGroupForPlayers();
+    if (candidate) {
+      this.groupForm.patchValue({ groupId: candidate.id }, { emitEvent: true });
+      if (this.isAlreadySelected && this.player1 && this.player2) {
+        this.step = 2;
+      }
+      return;
+    }
+
+    if (this.groups.length === 1) {
+      const [group] = this.groups;
+      this.groupForm.patchValue({ groupId: group.id }, { emitEvent: true });
+    }
+  }
+
+  private findGroupForPlayers(): Group | null {
+    if (!this.player1 && !this.player2) {
+      return null;
+    }
+
+    return this.groups.find(group => {
+      const members = new Set(group.players.map(player => Number(player.playerId)));
+      const player1Ok = !this.player1 || members.has(Number(this.player1.id));
+      const player2Ok = !this.player2 || members.has(Number(this.player2.id));
+      return player1Ok && player2Ok;
+    }) ?? null;
+  }
+
+  onBackToGroupSelection() {
+    this.step = 1;
+  }
+
+  onContinueToMatch() {
+    if (this.groupForm.invalid) {
+      this.groupForm.markAllAsTouched();
+      return;
+    }
+
+    this.step = 2;
+  }
+
+  private onGroupSelected(groupId: string, resetStep = true) {
+    this.matchForm.patchValue({ groupId, player1: null, player2: null }, { emitEvent: false });
+    const group = this.groups.find(g => g.id === groupId);
+    this.groupPlayers = group ? group.players.map(mapGroupPlayerToIPlayer) : [];
+
+    const groupMemberIds = new Set(this.groupPlayers.map(player => Number(player.id)));
+
+    if (this.player1 && !groupMemberIds.has(Number(this.player1.id))) {
+      this.player1 = null;
+    }
+    if (this.player2 && !groupMemberIds.has(Number(this.player2.id))) {
+      this.player2 = null;
+    }
+
+    this.matchForm.patchValue({
+      player1: this.player1?.id ?? null,
+      player2: this.player2?.id ?? null,
+    }, { emitEvent: false });
+
+    if (resetStep) {
+      this.step = 1;
+    }
+  }
+
+  getPlayers(playerNumber?: number): IPlayer[] {
+    const loggedInPlayerId = this.dataService.getLoggedInPlayerId();
+    let filtered = [...this.groupPlayers];
+
+    if (loggedInPlayerId != null) {
+      filtered = filtered.filter(player => Number(player.id) !== Number(loggedInPlayerId));
+    }
+
+    const selectedPlayer1 = this.matchForm.get('player1')?.value;
+    const selectedPlayer2 = this.matchForm.get('player2')?.value;
+
+    if (playerNumber === 1 && selectedPlayer2) {
+      filtered = filtered.filter(player => Number(player.id) !== Number(selectedPlayer2));
+    }
+
+    if (playerNumber === 2 && selectedPlayer1) {
+      filtered = filtered.filter(player => Number(player.id) !== Number(selectedPlayer1));
+    }
+
+    return filtered;
+  }
+
+  setPlayer(selection: { playerNumber: number; id: number }) {
+    this.matchForm.get(`player${selection.playerNumber}`)?.setValue(selection.id);
+  }
+
+  updateContainers() {
+    this.isShowSetsPointsTrue = this.matchForm.value.isShowSetsPointsTrue;
+    const totalPoints = (this.matchForm.value.p1Score || 0) + (this.matchForm.value.p2Score || 0);
+    const totalSets = this.isShowSetsPointsTrue ? Math.max(totalPoints, 1) : 0;
+
+    this.setsPoints.clear();
+    this.errorsOfPoints.length = 0;
+    for (let i = 0; i < totalSets && i < 10; i++) {
+      this.setsPoints.push(
+        this.fb.group({
+          player1Points: [0],
+          player2Points: [0],
+        })
+      );
+      this.getSetFormGroup(i).valueChanges.subscribe(() => this.checkPointsError());
+    }
+  }
+
+  sanitizeInput(controlName: 'p1Score' | 'p2Score') {
+    const control = this.matchForm.get(controlName);
+    const otherControlName = controlName === 'p1Score' ? 'p2Score' : 'p1Score';
+    const otherControl = this.matchForm.get(otherControlName);
+
+    if (!control) {
+      return;
+    }
+
+    const max = this.competition?.sets_type || this.maxSets;
+    let value = Number(control.value);
+
+    this.errorsOfSets.length = 0;
+
+    if (!Number.isNaN(value) && typeof control.value === 'string' && control.value.length > 1) {
+      value = Number(control.value.slice(-1));
+    }
+
+    if (Number.isNaN(value) || value < 0) {
+      value = 0;
+      this.errorsOfSets.push('number_positive');
+    }
+    if (value > max) {
+      value = max;
+      this.errorsOfSets.push(`number_maximum ${max}`);
+    }
+    if (otherControl && value === Number(otherControl.value)) {
+      value = Math.max(1, Math.min(value, max - 1));
+      this.errorsOfSets.push('number_equal');
+    }
+
+    if (control.value !== value) {
+      control.setValue(value, { emitEvent: true });
+    }
+  }
+
+  checkPointsError() {
+    this.errorsOfPoints.length = 0;
+
+    const maxPoints = this.competition?.points_type ?? this.maxPoints;
+
+    this.setsPoints.controls.forEach((setGroup: AbstractControl, index: number) => {
+      let p1 = Number(setGroup.get('player1Points')?.value);
+      let p2 = Number(setGroup.get('player2Points')?.value);
+
+      if (Number.isNaN(p1) || p1 < 0) {
+        this.errorsOfPoints.push(`set ${index + 1}: number_positive_p1`);
+        p1 = 0;
+      }
+      if (p1 > maxPoints) {
+        this.errorsOfPoints.push(`set ${index + 1}: number_maximum_p1 ${maxPoints}`);
+        p1 = maxPoints;
+      }
+
+      if (Number.isNaN(p2) || p2 < 0) {
+        this.errorsOfPoints.push(`set ${index + 1}: number_positive_p2`);
+        p2 = 0;
+      }
+      if (p2 > maxPoints) {
+        this.errorsOfPoints.push(`set ${index + 1}: number_maximum_p2 ${maxPoints}`);
+        p2 = maxPoints;
+      }
+
+      if (p1 === p2 && p1 > 0) {
+        this.errorsOfPoints.push(`set ${index + 1}`);
+      }
+
+      setGroup.patchValue({ player1Points: p1, player2Points: p2 }, { emitEvent: false });
+    });
+  }
+
+  async addMatch(event?: SubmitEvent) {
+    event?.preventDefault();
+
+    if (this.step !== 2) {
+      this.onContinueToMatch();
+      return;
+    }
+
+    if (this.matchForm.invalid) {
+      this.matchForm.markAllAsTouched();
+      return;
+    }
+
+    if (this.matchForm.value.player1 === this.matchForm.value.player2) {
+      alert('I Giocatori devono essere diversi!');
+      return;
+    }
+
+    const button = (event?.submitter as HTMLButtonElement) ?? undefined;
+    if (button) {
+      button.disabled = true;
+      this.loaderService.addSpinnerToButton(button);
+    }
+
+    try {
+      await this.sendData();
+    } catch (error) {
+      console.error('Error adding match:', error);
+    } finally {
+      if (button) {
+        button.disabled = false;
+        this.loaderService.removeSpinnerFromButton(button);
+      }
+    }
+  }
+
+  private async sendData(): Promise<void> {
+    if (this.matchForm.invalid) {
+      return;
+    }
+
+    this.isSending = true;
+    const dateInput = new Date(this.matchForm.value.date);
+    const today = new Date();
+
+    const formattedDate =
+      dateInput.toLocaleDateString('en-GB') +
+      ` - ${String(today.getHours()).padStart(2, '0')}:${String(today.getMinutes()).padStart(2, '0')}`;
+
+    const payload = {
+      date: formattedDate,
+      player1: this.matchForm.value.player1,
+      player2: this.matchForm.value.player2,
+      p1Score: this.matchForm.value.p1Score,
+      p2Score: this.matchForm.value.p2Score,
+      setsPoints: this.matchForm.value.setsPoints,
+      groupId: this.matchForm.value.groupId,
+    };
+
+    if (this.isShowSetsPointsTrue && (!payload.setsPoints || payload.setsPoints.length === 0)) {
+      this.loaderService.showToast(this.translateService.translate('sets_points_required'), MSG_TYPE.WARNING);
+      this.isSending = false;
+      return;
+    }
+
+    await this.dataService.addMatch(payload);
+    this.isSending = false;
+    this.closeModal();
+  }
+
+  closeModal() {
+    this.modalService.closeModal();
+    this.closeModalEvent.emit();
+  }
+
+  openManualPoints() {
+    this.openManualPointsEvent.emit();
+    this.modalService.openModal(this.modalService.MODALS['MANUAL_POINTS']);
+  }
+}

--- a/src/app/components/add-match-modal/add-group-match-modal/add-group-match-modal.component.ts
+++ b/src/app/components/add-match-modal/add-group-match-modal/add-group-match-modal.component.ts
@@ -160,7 +160,7 @@ export class AddGroupMatchModalComponent implements OnInit {
     }
 
     return this.groups.find(group => {
-      const members = new Set(group.players.map(player => Number(player.playerId)));
+      const members = new Set(group.players.map(player => Number(player.id)));
       const player1Ok = !this.player1 || members.has(Number(this.player1.id));
       const player2Ok = !this.player2 || members.has(Number(this.player2.id));
       return player1Ok && player2Ok;

--- a/src/app/components/add-match-modal/add-match-modal.component.ts
+++ b/src/app/components/add-match-modal/add-match-modal.component.ts
@@ -139,7 +139,7 @@ export class AddMatchModalComponent implements OnInit {
     if (this.isGroupKnockout() && selectedGroupId) {
       const group = this.groups.find(g => g.id === selectedGroupId);
       if (group) {
-        const allowedIds = new Set(group.players.map(member => Number(member.playerId)));
+        const allowedIds = new Set(group.players.map(member => Number(member.id)));
         filteredPlayers = filteredPlayers.filter(p => allowedIds.has(Number(p.id)));
       }
     }

--- a/src/app/components/add-match-modal/manual-points/manual-points.component.html
+++ b/src/app/components/add-match-modal/manual-points/manual-points.component.html
@@ -1,100 +1,120 @@
 <div class="manual-points" [ngClass]="{ mobile: isMobile, desktop: !isMobile }">
-    <ng-container *ngIf="!selectingPlayer && !isCompleted()">
-        <div class="sets-container">
-            {{player1SetsPoints}} - {{player2SetsPoints}}
-        </div>
-        <div class="microphone-container text-center">
-            <app-voice-score (scoreChanged)="onScoreChanged($event)"></app-voice-score>
-        </div>
-        <div class="container-points">
-            <div #effectLeft class="points box box1">
-                <button class="tap" (click)="changePoint(1)">
-                    <span class="big-point">{{player1Points}}</span>
-                    <div class="player-indicator left">
-                        <img [src]="player1?.image_url || './default-player.jpg'" alt="">
-                        <div> {{ player1?.nickname }}</div>
-                    </div>
-                </button>
-                <button class="minus" (click)="subtractPoint(1)"><i class="fa-solid fa-minus"></i></button>
-            </div>
-            <div #effectRight class="points box box2">
-                <button class="tap" (click)="changePoint(2)">
-                    <span class="big-point">{{player2Points}}</span>
-                    <div class="player-indicator right">
-                        <img [src]="player2?.image_url || './default-player.jpg'" alt="">
-                        <div> {{ player2?.nickname }}</div>
-                    </div>
-                </button>
-                <button class="minus" (click)="subtractPoint(2)"><i class="fa-solid fa-minus"></i></button>
-            </div>
+  <app-step-indicator [activeStep]="step" [totalSteps]="totalSteps"></app-step-indicator>
+
+  <form *ngIf="isGroupSelectionStep && !isCompleted()" class="form-dark group-form" [formGroup]="groupForm">
+    <label for="groupId" class="my-placeholder">{{ 'group_knockout_board_group' | translate }}</label>
+    <select id="groupId" class="my-placeholder" formControlName="groupId" required>
+      <option [ngValue]="null">{{ 'select_group' | translate }}</option>
+      <option *ngFor="let group of availableGroups" [ngValue]="group.id">{{ group.name }}</option>
+    </select>
+    <div class="modal-buttons d-flex justify-content-end mt-4">
+      <button type="button" class="btn btn-primary" (click)="onGroupContinue()" [disabled]="groupForm.invalid">
+        {{ 'continue' | translate }}
+      </button>
+    </div>
+  </form>
+
+  <div *ngIf="isPlayerSelectionStep && !isPointsStep && !isCompleted()" class="container my-4">
+    <form class="form-dark" [formGroup]="playersForm">
+      <p class="text-center mb-4">
+        {{ 'manual_points_description' | translate }}
+      </p>
+
+      <div class="row align-items-center justify-content-center">
+        <div class="col-12 col-md-5 mb-3 mb-md-0">
+          <app-select-player [players]="getPlayers(1)" [playerNumber]="'1'" [initialPlayer]="player1"
+            (playerSelected)="setPlayer($event)">
+          </app-select-player>
         </div>
 
-        <div class="actions">
-            <button type="button" *ngIf="!isCompleted()" class="bg-primary" (click)="onSave()"
-                [disabled]="isPointsError(player1Points, player2Points, maxPoints)">
-                {{'save_points' | translate}}
-            </button>
-
-            <button type="button" class="reset" (click)="onReset()">
-                {{'reset_points' | translate}}
-            </button>
+        <div class="col-12 col-md-2 text-center mb-3 mb-md-0 fw-bold">
+          {{ 'vs' | translate }}
         </div>
-    </ng-container>
 
-    <div *ngIf="selectingPlayer && !isCompleted()" class="container my-4">
-        <form class="form-dark" [formGroup]="playersForm">
-            <p class="text-center mb-4">
-                {{ 'manual_points_description' | translate }}
-            </p>
+        <div class="col-12 col-md-5">
+          <app-select-player [players]="getPlayers(2)" [playerNumber]="'2'" [initialPlayer]="player2"
+            (playerSelected)="setPlayer($event)">
+          </app-select-player>
+        </div>
+      </div>
 
-            <div class="row align-items-center justify-content-center">
-                <!-- Player 1 -->
-                <div class="col-12 col-md-5 mb-3 mb-md-0">
-                    <app-select-player [players]="getPlayers(1)" [playerNumber]="'1'" [initialPlayer]="player1"
-                        (playerSelected)="setPlayer($event)">
-                    </app-select-player>
-                </div>
+      <div class="d-flex justify-content-center mt-4">
+        <button type="button" class="btn btn-primary px-4 position-relative" (click)="onPlayersContinue()"
+          [disabled]="playersForm.invalid">
+          {{ 'continue' | translate }}
+        </button>
+      </div>
+    </form>
+  </div>
 
-                <!-- VS -->
-                <div class="col-12 col-md-2 text-center mb-3 mb-md-0 fw-bold">
-                    {{ 'vs' | translate }}
-                </div>
-
-                <!-- Player 2 -->
-                <div class="col-12 col-md-5">
-                    <app-select-player [players]="getPlayers(2)" [playerNumber]="'2'" [initialPlayer]="player2"
-                        (playerSelected)="setPlayer($event)">
-                    </app-select-player>
-                </div>
-            </div>
-
-            <div class="d-flex justify-content-center mt-4">
-                <button type="button" class="btn btn-primary px-4 position-relative" (click)="onContinue()"
-                    [disabled]="playersForm.invalid">
-                    {{ 'continue' | translate }}
-                </button>
-            </div>
-        </form>
+  <ng-container *ngIf="isPointsStep && !isCompleted()">
+    <div class="step-actions d-flex justify-content-between mb-3">
+      <div *ngIf="selectedGroup" class="selected-group">
+        <span>{{ 'group_knockout_board_group' | translate }}: <strong>{{ selectedGroup.name }}</strong></span>
+        <button type="button" class="link" *ngIf="showGroupControls" (click)="onGroupBack()">{{ 'edit' | translate }}</button>
+      </div>
+      <button type="button" class="link" (click)="onPlayersBack()">{{ 'edit' | translate }}</button>
     </div>
 
-    <div *ngIf="isCompleted()">
-        <div class="summary mt-5" *ngIf="sets.length > 0">
-            <h3>{{ 'match_summary' | translate }}</h3>
-            <ul>
-                <li *ngFor="let set of sets; let i = index">
-                    <span>Set {{ i + 1 }}</span>
-                    <span>{{ set.player1 }} - {{ set.player2 }}</span>
-                </li>
-                <li class="total">
-                    <span>Total</span>
-                    <span>{{ player1SetsPoints }} - {{ player2SetsPoints }}</span>
-                </li>
-            </ul>
-        </div>
-        <div class="actions mt-5">
-            <button type="button" class="secondary" (click)="saveMatch($event.target)">
-                {{'completed_match_save' | translate}}
-            </button>
-        </div>
+    <div class="sets-container">
+      {{ player1SetsPoints }} - {{ player2SetsPoints }}
     </div>
+    <div class="microphone-container text-center">
+      <app-voice-score (scoreChanged)="onScoreChanged($event)"></app-voice-score>
+    </div>
+    <div class="container-points">
+      <div #effectLeft class="points box box1">
+        <button class="tap" (click)="changePoint(1)">
+          <span class="big-point">{{ player1Points }}</span>
+          <div class="player-indicator left">
+            <img [src]="player1?.image_url || './default-player.jpg'" alt="">
+            <div>{{ player1?.nickname }}</div>
+          </div>
+        </button>
+        <button class="minus" (click)="subtractPoint(1)"><i class="fa-solid fa-minus"></i></button>
+      </div>
+      <div #effectRight class="points box box2">
+        <button class="tap" (click)="changePoint(2)">
+          <span class="big-point">{{ player2Points }}</span>
+          <div class="player-indicator right">
+            <img [src]="player2?.image_url || './default-player.jpg'" alt="">
+            <div>{{ player2?.nickname }}</div>
+          </div>
+        </button>
+        <button class="minus" (click)="subtractPoint(2)"><i class="fa-solid fa-minus"></i></button>
+      </div>
+    </div>
+
+    <div class="actions">
+      <button type="button" class="bg-primary" (click)="onSave()"
+        [disabled]="isPointsError(player1Points, player2Points, maxPoints)">
+        {{ 'save_points' | translate }}
+      </button>
+
+      <button type="button" class="reset" (click)="onReset()">
+        {{ 'reset_points' | translate }}
+      </button>
+    </div>
+  </ng-container>
+
+  <div *ngIf="isCompleted()">
+    <div class="summary mt-5" *ngIf="sets.length > 0">
+      <h3>{{ 'match_summary' | translate }}</h3>
+      <ul>
+        <li *ngFor="let set of sets; let i = index">
+          <span>Set {{ i + 1 }}</span>
+          <span>{{ set.player1 }} - {{ set.player2 }}</span>
+        </li>
+        <li class="total">
+          <span>Total</span>
+          <span>{{ player1SetsPoints }} - {{ player2SetsPoints }}</span>
+        </li>
+      </ul>
+    </div>
+    <div class="actions mt-5">
+      <button type="button" class="secondary" (click)="saveMatch($event.target)">
+        {{ 'completed_match_save' | translate }}
+      </button>
+    </div>
+  </div>
 </div>

--- a/src/app/components/add-match-modal/manual-points/manual-points.component.scss
+++ b/src/app/components/add-match-modal/manual-points/manual-points.component.scss
@@ -1,6 +1,10 @@
 @use '../../../../style/variables.scss' as *;
 
 .manual-points {
+    .group-form {
+        margin-top: 1rem;
+    }
+
     .container-points {
         padding: 5em;
         display: grid;
@@ -84,6 +88,19 @@
         margin: auto;
     }
 
+}
+
+.step-actions {
+    align-items: center;
+
+    .link {
+        background: none;
+        border: none;
+        color: $primary;
+        text-decoration: underline;
+        cursor: pointer;
+        padding: 0;
+    }
 }
 
 .microphone-container {

--- a/src/app/components/add-match-modal/manual-points/manual-points.component.ts
+++ b/src/app/components/add-match-modal/manual-points/manual-points.component.ts
@@ -285,7 +285,7 @@ export class ManualPointsComponent implements OnChanges, OnInit {
     }
 
     return groups.find(group => {
-      const members = new Set(group.players.map(member => Number(member.playerId)));
+      const members = new Set(group.players.map(member => Number(member.id)));
       const player1Ok = !this.player1 || members.has(Number(this.player1.id));
       const player2Ok = !this.player2 || members.has(Number(this.player2.id));
       return player1Ok && player2Ok;
@@ -493,7 +493,7 @@ export class ManualPointsComponent implements OnChanges, OnInit {
       player2Points: s.player2 ?? s.player2 ?? 0
     }));
 
-    const formData: Record<string, unknown> = {
+    const formData: { [key: string]: any; p1Score: number; p2Score: number; groupId?: string | null } = {
       date: formattedDate,
       player1: this.player1.id,
       player2: this.player2.id,
@@ -503,7 +503,7 @@ export class ManualPointsComponent implements OnChanges, OnInit {
     };
 
     if (this.isGroupMode && this.selectedGroupId) {
-      formData['groupId'] = this.selectedGroupId;
+      formData.groupId = this.selectedGroupId;
     }
 
     this.dataService.addMatch(formData).then(() => {

--- a/src/app/components/add-match-modal/manual-points/manual-points.component.ts
+++ b/src/app/components/add-match-modal/manual-points/manual-points.component.ts
@@ -1,28 +1,30 @@
-import { Component, ElementRef, EventEmitter, HostListener, inject, Input, Output, ViewChild } from '@angular/core';
+import { Component, ElementRef, EventEmitter, HostListener, Input, OnChanges, OnInit, Output, SimpleChanges, ViewChild } from '@angular/core';
 import { SHARED_IMPORTS } from '../../../common/imports/shared.imports';
 import { IPlayer } from '../../../../services/players.service';
 import { CompetitionService } from '../../../../services/competitions.service';
 import { ICompetition } from '../../../../api/competition.api';
 import { DataService } from '../../../../services/data.service';
-import { AbstractControl, FormBuilder, FormGroup, ValidationErrors, ValidatorFn, Validators } from '@angular/forms';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { SelectPlayerComponent } from '../../../utils/components/select-player/select-player.component';
 import { VoiceScoreComponent } from './voice-score/voice-score.component';
 import { ModalService } from '../../../../services/modal.service';
 import { LoaderService } from '../../../../services/loader.service';
 import { Utils } from '../../../utils/Utils';
+import { StepIndicatorComponent } from '../../../common/step-indicator/step-indicator.component';
+import { Group, mapGroupPlayerToIPlayer } from '../../../interfaces/group.interface';
 
 @Component({
   selector: 'app-manual-points',
-  imports: [SHARED_IMPORTS, SelectPlayerComponent, VoiceScoreComponent],
+  imports: [SHARED_IMPORTS, SelectPlayerComponent, VoiceScoreComponent, StepIndicatorComponent],
   templateUrl: './manual-points.component.html',
   styleUrl: './manual-points.component.scss'
 })
-export class ManualPointsComponent {
+export class ManualPointsComponent implements OnChanges, OnInit {
 
   @Output() close = new EventEmitter<any>();
   @ViewChild('effectLeft') effectLeft!: ElementRef;
   @ViewChild('effectRight') effectRight!: ElementRef;
-  @Input() isAlreadySelected: boolean = false;
+  @Input() isAlreadySelected = false;
 
   @Input() maxSets = 5;
   @Input() maxPoints = 21;
@@ -30,7 +32,10 @@ export class ManualPointsComponent {
   @Input() player2: IPlayer | null = null;
   @Input() player1: IPlayer | null = null;
   @Input() players: IPlayer[] = [];
+  @Input() groups: Group[] = [];
+  @Input() isGroupKnockout = false;
 
+  groupForm!: FormGroup;
   playersForm!: FormGroup;
 
   player1Points = 0;
@@ -39,45 +44,61 @@ export class ManualPointsComponent {
   player1SetsPoints = 0;
   player2SetsPoints = 0;
   sets: Array<{ player1: number; player2: number }> = [];
-  competitionService = inject(CompetitionService);
   competition: ICompetition | null = null;
   isMobile = false;
-  selectingPlayer: boolean = true;
 
-  constructor(private dataService: DataService, private fb: FormBuilder, private modalService: ModalService, private loaderService: LoaderService) { }
+  step = 1;
+  totalSteps = 2;
 
-  ngOnChanges() {
-    console.info('player1 value:', this.player1);
-    console.info('player2 value:', this.player2);
-    if (this.playersForm) {
-      this.playersForm.patchValue({
-        player1: this.player1 || null,
-        player2: this.player2 || null
-      });
+  private isGroupMode = false;
+  private groupsFromService: Group[] = [];
+  private skipPlayerReset = false;
+  private selectedGroupId: string | null = null;
+  private groupPlayers: IPlayer[] = [];
+
+  constructor(
+    private dataService: DataService,
+    private fb: FormBuilder,
+    private modalService: ModalService,
+    private loaderService: LoaderService,
+    private competitionService: CompetitionService,
+  ) { }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes['player1'] || changes['player2']) {
+      if (this.playersForm) {
+        this.playersForm.patchValue({
+          player1: this.player1?.id ?? null,
+          player2: this.player2?.id ?? null,
+        }, { emitEvent: false });
+      }
+    }
+
+    if (changes['groups']) {
+      this.trySelectGroup();
     }
   }
 
-
   ngOnInit() {
     this.checkViewport();
+    this.initForms();
+    this.updateMode();
+
     this.competitionService.activeCompetition$.subscribe(comp => {
       this.competition = comp;
       this.maxPoints = this.competition?.['points_type'] || 21;
       this.initialMaxPoints = this.maxPoints;
       this.maxSets = this.competition?.['sets_type'] || 10;
+      this.updateMode();
     });
-    this.playersForm = this.fb.group({
-      player1: [this.player1?.id, Validators.required],
-      player2: [this.player2?.id, Validators.required]
+
+    this.dataService.groupsObs.subscribe(groups => {
+      this.groupsFromService = groups ?? [];
+      this.trySelectGroup();
     });
-    this.playersForm.valueChanges.subscribe((val) => {
-      this.player1 = this.players.find(p => p.id === val.player1) || null;
-      this.player2 = this.players.find(p => p.id === val.player2) || null;
-      console.log(val, this.player1, this.player2);
-    });
-    
+
     if (this.isAlreadySelected && this.player1 && this.player2) {
-      this.selectingPlayer = false;
+      this.step = this.totalSteps;
     }
   }
 
@@ -86,19 +107,235 @@ export class ManualPointsComponent {
     this.checkViewport();
   }
 
+  get isGroupSelectionStep(): boolean {
+    return this.isGroupMode && this.step === 1;
+  }
+
+  get isPlayerSelectionStep(): boolean {
+    return this.isGroupMode ? this.step === 2 : this.step === 1;
+  }
+
+  get isPointsStep(): boolean {
+    return this.step === this.totalSteps;
+  }
+
+  get showGroupControls(): boolean {
+    return this.isGroupMode;
+  }
+
+  get selectedGroup(): Group | null {
+    const groups = this.availableGroups;
+    return groups.find(group => group.id === this.selectedGroupId) ?? null;
+  }
+
+  get availablePlayers(): IPlayer[] {
+    if (this.isGroupMode) {
+      return this.groupPlayers.length ? this.groupPlayers : [];
+    }
+
+    return this.players ?? [];
+  }
+
+  get availableGroups(): Group[] {
+    return this.groups?.length ? this.groups : this.groupsFromService;
+  }
+
+  private initForms() {
+    this.groupForm = this.fb.group({
+      groupId: [null, Validators.required],
+    });
+
+    this.groupForm.get('groupId')?.valueChanges.subscribe(groupId => {
+      this.onGroupChanged(groupId ?? null);
+    });
+
+    this.playersForm = this.fb.group({
+      player1: [this.player1?.id ?? null, Validators.required],
+      player2: [this.player2?.id ?? null, Validators.required],
+    });
+
+    this.playersForm.valueChanges.subscribe(val => {
+      this.player1 = this.findPlayerById(val.player1);
+      this.player2 = this.findPlayerById(val.player2);
+    });
+  }
+
+  private updateMode() {
+    const competitionType = this.competition?.type ?? null;
+    this.isGroupMode = this.isGroupKnockout || competitionType === 'group_knockout';
+    this.totalSteps = this.isGroupMode ? 3 : 2;
+    this.step = Math.min(this.step, this.totalSteps);
+
+    if (!this.isGroupMode) {
+      this.selectedGroupId = null;
+      this.groupPlayers = [];
+    } else {
+      this.trySelectGroup();
+    }
+  }
+
   private checkViewport() {
-    this.isMobile = window.innerWidth <= 768 || window.innerWidth < window.innerHeight; // breakpoint mobile
+    this.isMobile = window.innerWidth <= 768 || window.innerWidth < window.innerHeight;
+  }
+
+  onGroupContinue() {
+    if (this.groupForm.invalid) {
+      this.groupForm.markAllAsTouched();
+      return;
+    }
+
+    this.step = Math.max(this.step, 2);
+  }
+
+  onPlayersContinue() {
+    if (this.playersForm.invalid) {
+      this.playersForm.markAllAsTouched();
+      return;
+    }
+
+    this.player1 = this.findPlayerById(this.playersForm.get('player1')?.value ?? null);
+    this.player2 = this.findPlayerById(this.playersForm.get('player2')?.value ?? null);
+
+    if (!this.player1 || !this.player2) {
+      return;
+    }
+
+    this.step = this.totalSteps;
+  }
+
+  private onGroupChanged(groupId: string | null) {
+    this.selectedGroupId = groupId;
+    this.updateGroupPlayers();
+    this.syncPlayersWithGroup();
+
+    if (this.isGroupMode && !this.skipPlayerReset) {
+      this.step = Math.min(this.step, this.totalSteps - 1);
+    }
+
+    this.skipPlayerReset = false;
+  }
+
+  private updateGroupPlayers() {
+    if (!this.isGroupMode || !this.selectedGroupId) {
+      this.groupPlayers = [];
+      return;
+    }
+
+    const groups = this.availableGroups;
+    const group = groups.find(item => item.id === this.selectedGroupId) ?? null;
+    this.groupPlayers = group ? group.players.map(mapGroupPlayerToIPlayer) : [];
+  }
+
+  private syncPlayersWithGroup() {
+    if (!this.isGroupMode) {
+      return;
+    }
+
+    const allowedIds = new Set(this.groupPlayers.map(player => Number(player.id)));
+
+    if (this.player1 && !allowedIds.has(Number(this.player1.id))) {
+      this.player1 = null;
+    }
+
+    if (this.player2 && !allowedIds.has(Number(this.player2.id))) {
+      this.player2 = null;
+    }
+
+    this.playersForm.patchValue({
+      player1: this.player1?.id ?? null,
+      player2: this.player2?.id ?? null,
+    }, { emitEvent: false });
+  }
+
+  private trySelectGroup() {
+    if (!this.isGroupMode) {
+      return;
+    }
+
+    const groups = this.availableGroups;
+    if (!groups.length) {
+      return;
+    }
+
+    if (this.selectedGroupId) {
+      this.updateGroupPlayers();
+      return;
+    }
+
+    const candidate = this.findGroupForPlayers(groups);
+    if (candidate) {
+      this.skipPlayerReset = true;
+      this.groupForm.patchValue({ groupId: candidate.id }, { emitEvent: true });
+      if (this.isAlreadySelected && this.player1 && this.player2) {
+        this.step = this.totalSteps;
+      }
+      return;
+    }
+
+    if (groups.length === 1) {
+      this.skipPlayerReset = true;
+      this.groupForm.patchValue({ groupId: groups[0].id }, { emitEvent: true });
+      return;
+    }
+  }
+
+  private findGroupForPlayers(groups: Group[]): Group | null {
+    if (!this.player1 && !this.player2) {
+      return null;
+    }
+
+    return groups.find(group => {
+      const members = new Set(group.players.map(member => Number(member.playerId)));
+      const player1Ok = !this.player1 || members.has(Number(this.player1.id));
+      const player2Ok = !this.player2 || members.has(Number(this.player2.id));
+      return player1Ok && player2Ok;
+    }) ?? null;
+  }
+
+  private findPlayerById(id: number | null): IPlayer | null {
+    if (id == null) {
+      return null;
+    }
+
+    const source = this.isGroupMode ? this.groupPlayers : this.players;
+    return source.find(player => Number(player.id) === Number(id)) ?? null;
+  }
+
+  getPlayers(player?: number): IPlayer[] {
+    const basePlayers = this.availablePlayers;
+    if (!basePlayers.length) {
+      return [];
+    }
+
+    const loggedInPlayerId = this.dataService.getLoggedInPlayerId();
+    let filtered = basePlayers.filter(p => Number(p.id) !== Number(loggedInPlayerId));
+
+    const selectedPlayer1 = this.playersForm.get('player1')?.value;
+    const selectedPlayer2 = this.playersForm.get('player2')?.value;
+
+    if (player === 1 && selectedPlayer2) {
+      filtered = filtered.filter(p => Number(p.id) !== Number(selectedPlayer2));
+    }
+
+    if (player === 2 && selectedPlayer1) {
+      filtered = filtered.filter(p => Number(p.id) !== Number(selectedPlayer1));
+    }
+
+    return filtered;
+  }
+
+  setPlayer(player: { playerNumber: number; id: number }) {
+    this.playersForm.get(`player${player.playerNumber}`)?.setValue(player.id);
   }
 
   onScoreChanged(event: { p1: number; p2: number }) {
-    // Clamp points to maxPoints
-    event.p1 = Math.min(event.p1, this.maxPoints + 1); // +1 per permettere il vantaggio
-    event.p2 = Math.min(event.p2, this.maxPoints + 1); // +1 per permettere il vantaggio
+    event.p1 = Math.min(event.p1, this.maxPoints + 1);
+    event.p2 = Math.min(event.p2, this.maxPoints + 1);
     if (this.effectLeft && this.effectLeft.nativeElement) {
-      if (this.player1Points != event.p1) {
+      if (this.player1Points !== event.p1) {
         this.triggerHighlight(this.effectLeft);
       }
-      if (this.player2Points != event.p2) {
+      if (this.player2Points !== event.p2) {
         this.triggerHighlight(this.effectRight);
       }
     }
@@ -107,9 +344,6 @@ export class ManualPointsComponent {
   }
 
   changePoint(player: number) {
-    console.log('Change point for player', player, this.player1Points, this.player2Points, this.player1, this.player2);
-
-    // Allow increment if under maxPoints, or if both at least maxPoints and difference < 2 (advantage rule)
     if (
       (player === 1 &&
         (this.player1Points < this.maxPoints ||
@@ -129,7 +363,6 @@ export class ManualPointsComponent {
         this.player2Points++;
         this.triggerHighlight(this.effectRight);
       }
-      // If both players reach maxPoints, increase maxPoints by 2 for advantage
       if (this.player1Points >= this.maxPoints && this.player2Points >= this.maxPoints && Math.abs(this.player1Points - this.player2Points) < 2) {
         this.maxPoints += 2;
       }
@@ -144,11 +377,9 @@ export class ManualPointsComponent {
       this.player2Points--;
       this.recalculateMaxPoints();
     }
-    console.log(this.maxPoints)
   }
 
   private recalculateMaxPoints() {
-    // Decrease maxPoints only if both players have at least initialMaxPoints - 1 and the difference is less than 2
     if (
       this.player1Points >= this.initialMaxPoints - 1 &&
       this.player2Points >= this.initialMaxPoints - 1 &&
@@ -159,35 +390,17 @@ export class ManualPointsComponent {
     }
   }
 
-  getPlayers(player?: number): any[] {
-    if (!this.players || this.players.length === 0) return [];
-
-    const loggedInPlayerId = this.dataService.getLoggedInPlayerId();
-    let filteredPlayers = this.players.filter(p => p.id !== loggedInPlayerId);
-
-    const selectedPlayer1 = this.playersForm.get('player1')?.value;
-    const selectedPlayer2 = this.playersForm.get('player2')?.value;
-
-    if (player === 1 && selectedPlayer2) {
-      filteredPlayers = filteredPlayers.filter(p => p.id !== selectedPlayer2);
+  onPlayersBack() {
+    if (this.isGroupMode) {
+      this.step = 2;
+      return;
     }
-
-    if (player === 2 && selectedPlayer1) {
-      filteredPlayers = filteredPlayers.filter(p => p.id !== selectedPlayer1);
-    }
-
-    return filteredPlayers;
+    this.step = 1;
   }
 
-  setPlayer(player: any) {
-    this.playersForm.get(`player${player.playerNumber}`)?.setValue(player.id);
-  }
-
-  onContinue() {
-    if (this.playersForm.valid) {
-      this.player1 = this.players.find(p => p.id === this.playersForm.get('player1')?.value) || null;
-      this.player2 = this.players.find(p => p.id === this.playersForm.get('player2')?.value) || null;
-      this.selectingPlayer = false;
+  onGroupBack() {
+    if (this.isGroupMode) {
+      this.step = 1;
     }
   }
 
@@ -208,7 +421,6 @@ export class ManualPointsComponent {
     this.player2Points = 0;
 
     this.maxPoints = this.initialMaxPoints;
-    // Trigger the highlight animation on reset for both players
     if (this.effectRight && this.effectRight.nativeElement) {
       this.triggerHighlight(this.effectRight);
     }
@@ -217,65 +429,52 @@ export class ManualPointsComponent {
     }
   }
 
-  // Restituisce true se la situazione dei punti NON è valida secondo le regole del vantaggio
   isPointsError(p1: number, p2: number, maxPoints: number): boolean {
-    // Caso iniziale
     if (p1 === 0 && p2 === 0) return true;
 
     const diff = Math.abs(p1 - p2);
     const max = Math.max(p1, p2);
     const min = Math.min(p1, p2);
-    // Entrambi sotto al maxPoints → nessun vincitore
     if (p1 < maxPoints && p2 < maxPoints) return true;
 
-    // Qualcuno ha raggiunto almeno maxPoints
     if (max >= maxPoints) {
-      // Per essere valido: differenza >= 2 e l'altro almeno a maxPoints - 1
       if (diff >= 2) {
-        console.log('isPointsError: diff < 2 or min < maxPoints - 1');
         if (p1 >= this.initialMaxPoints - 1 && p2 > this.initialMaxPoints - 1 && diff > 2) {
-          return true; // punteggio non valido
+          return true;
         }
-        return false; // punteggio valido
-
+        return false;
       }
-      console.log('isPointsError: diff < 2 or min < maxPoints - 1');
-      return true; // ancora non valido
+      return true;
     }
-    console.log('Unexpected case in isPointsError');
     return true;
   }
-  // Trigger highlight animation without flashes
+
   private triggerHighlight(el: ElementRef) {
     if (!el || !el.nativeElement) return;
 
     const element = el.nativeElement;
 
-    // reset animation
     element.style.animation = 'none';
-    element.offsetHeight; // force reflow
-    element.style.animation = ''; // restore
+    element.offsetHeight;
+    element.style.animation = '';
 
-    // reapply the class (keeps CSS control)
     element.classList.add(Utils.isIos() ? 'highlight-once-mobile' : 'highlight-once');
 
-    // quando finisce l’animazione la rimuovo
     element.addEventListener('animationend', () => {
       element.classList.remove(Utils.isIos() ? 'highlight-once-mobile' : 'highlight-once');
     }, { once: true });
   }
+
   isCompleted(): boolean {
     return this.player1SetsPoints >= this.maxSets || this.player2SetsPoints >= this.maxSets;
   }
-  saveMatch(target: EventTarget | null) {
 
-    // 1. Verifica che la partita sia completata
+  saveMatch(target: EventTarget | null) {
     if (!this.isCompleted()) {
       alert('La partita non è ancora conclusa!');
       return;
     }
 
-    // 2. Verifica che i giocatori siano selezionati
     if (!this.player1 || !this.player2) {
       alert('Seleziona entrambi i giocatori!');
       return;
@@ -283,7 +482,7 @@ export class ManualPointsComponent {
     if (target instanceof HTMLElement) {
       this.loaderService.addSpinnerToButton(target);
     }
-    // 3. Prepara data e ora
+
     const today = new Date();
     const formattedDate =
       today.toLocaleDateString('en-GB') +
@@ -294,19 +493,19 @@ export class ManualPointsComponent {
       player2Points: s.player2 ?? s.player2 ?? 0
     }));
 
-    // 4. Prepara l’oggetto da salvare
-    const formData = {
+    const formData: Record<string, unknown> = {
       date: formattedDate,
       player1: this.player1.id,
       player2: this.player2.id,
-      p1Score: this.player1SetsPoints,  // set vinti da player1
-      p2Score: this.player2SetsPoints,  // set vinti da player2
-      setsPoints: setsData
+      p1Score: this.player1SetsPoints,
+      p2Score: this.player2SetsPoints,
+      setsPoints: setsData,
     };
 
-    console.log('Saving manual match...', formData);
+    if (this.isGroupMode && this.selectedGroupId) {
+      formData['groupId'] = this.selectedGroupId;
+    }
 
-    // 5. Chiamata al service
     this.dataService.addMatch(formData).then(() => {
       this.modalService.closeModal();
       if (target instanceof HTMLElement) {

--- a/src/app/components/group-knockout/group-knockout-board.component.ts
+++ b/src/app/components/group-knockout/group-knockout-board.component.ts
@@ -21,7 +21,7 @@ export class GroupKnockoutBoardComponent {
   }
 
   trackByPlayer(_index: number, player: GroupPlayer) {
-    return player.playerId;
+    return player.id;
   }
 
   getInitials(player: GroupPlayer): string {

--- a/src/app/components/home.component.html
+++ b/src/app/components/home.component.html
@@ -1,66 +1,31 @@
 <div class="wrapper">
-    <ng-container *ngIf="userState$ | async as state">
-        <ng-container [ngSwitch]="activeCompetition?.type">
-            <ng-container *ngSwitchCase="'elimination'">
-                <div class="wrapper" *ngIf="competitionQualifiedPlayers.length >= 2 && activeCompetition">
-                    <app-elimination-bracket (playersSelected)="onClickRound($event)" [competition]="activeCompetition"
-                        [rounds]="eliminationRounds"></app-elimination-bracket>
-                </div>
-            </ng-container>
-            <app-group-knockout *ngSwitchCase="'group_knockout'" [competition]="activeCompetition"
-                [groups]="groups" [qualifiedPlayers]="competitionQualifiedPlayers"
-                [rounds]="eliminationRounds" (roundSelected)="onClickRound($event)"></app-group-knockout>
-            <ng-container *ngSwitchDefault>
-                <div class="league-wrapper">
-                    <p *ngIf="matches.length === 0" class="mt-4 text-center">
-                        {{ "matches_not_found" | translate }}
-                    </p>
-                    <section>
-                        <app-matches *ngIf="matches.length > 0" [matches]="matches"
-                            (matchEmitter)="setClickedMatch($event)">
-                        </app-matches>
-                        <div class="buttons-home-matches">
-                            <div class="button-container mt-3">
-                                <button type="button" (click)="modalService.openModal(modalService.MODALS['ADD_MATCH'])"
-                                    class="add-match p-2 text-center">
-                                    {{ "add_match" | translate}}
-                                    <span class="m-1"></span>
-                                    <i class="fa fa-file-text-o" aria-hidden="true"></i>
-                                </button>
-                                <p class="small text-center mt-3">
-                                    {{ "add_match_description" | translate }}
-                                </p>
-                            </div>
-                            <div class="button-container">
-                                <div>
-                                    <button type="button" class="bg-secondary position-relative p-2 text-center"
-                                        (click)="modalService.openModal(modalService.MODALS['MANUAL_POINTS'])">
-                                        {{ "add_manual_set_points" | translate }}
-                                        <div class="circle-live"></div>
-                                    </button>
-                                </div>
-                                <p class="small text-center mt-3">
-                                    {{ "add_manual_set_points_description" | translate }}
-                                </p>
-                            </div>
-                        </div>
-                    </section>
-                    <section>
-                        <app-stats *ngIf="matches.length > 0"></app-stats>
-                    </section>
-                </div>
-            </ng-container>
-        </ng-container>
+  <ng-container *ngIf="userState$ | async">
+    <ng-container [ngSwitch]="activeCompetition?.type">
+      <app-elimination-bracket *ngSwitchCase="'elimination'" (playersSelected)="onClickRound($event)"
+        [competition]="activeCompetition" [rounds]="eliminationRounds"></app-elimination-bracket>
 
-        <app-bottom-navbar class="bottom-navbar"></app-bottom-navbar>
+      <app-group-knockout *ngSwitchCase="'group_knockout'" [competition]="activeCompetition" [groups]="groups"
+        [qualifiedPlayers]="competitionQualifiedPlayers" [rounds]="eliminationRounds"
+        (roundSelected)="onClickRound($event)"></app-group-knockout>
+
+      <app-league-board *ngSwitchDefault [matches]="matches" (matchSelected)="setClickedMatch($event)">
+      </app-league-board>
     </ng-container>
+
+    <app-bottom-navbar class="bottom-navbar"></app-bottom-navbar>
+  </ng-container>
 </div>
 
 <app-modal [label]="'add_match'" *ngIf="modalService.isActiveModal(modalService.MODALS['ADD_MATCH'])"
-    [modalName]="modalService.MODALS['ADD_MATCH']">
+  [modalName]="modalService.MODALS['ADD_MATCH']">
+  <ng-container *ngIf="isGroupKnockoutMode; else standardMatchModal">
+    <app-add-group-match-modal [isAlreadySelected]="!!player1Selected && !!player2Selected"
+      [player1]="player1Selected" [player2]="player2Selected"></app-add-group-match-modal>
+  </ng-container>
+  <ng-template #standardMatchModal>
     <add-match-modal [isAlreadySelected]="!!player1Selected && !!player2Selected" [players]="modalPlayers"
-        [groups]="groups"
-        [player1]="player1Selected" [player2]="player2Selected"></add-match-modal>
+      [groups]="groups" [player1]="player1Selected" [player2]="player2Selected"></add-match-modal>
+  </ng-template>
 </app-modal>
 
 <app-modal [label]="'match_details'" *ngIf="modalService.isActiveModal(modalService.MODALS['SHOW_MATCH'])"
@@ -70,7 +35,8 @@
 
 <app-modal [fullscreen]="true" [label]="'manual_points'"
     *ngIf="modalService.isActiveModal(modalService.MODALS['MANUAL_POINTS'])"
-    [modalName]="modalService.MODALS['MANUAL_POINTS']" class="manual-points-modal">
-    <app-manual-points [isAlreadySelected]="!!player1Selected && !!player2Selected" [players]="modalPlayers"
-        [player1]="player1Selected" [player2]="player2Selected"></app-manual-points>
+  [modalName]="modalService.MODALS['MANUAL_POINTS']" class="manual-points-modal">
+  <app-manual-points [isAlreadySelected]="!!player1Selected && !!player2Selected" [players]="modalPlayers"
+    [player1]="player1Selected" [player2]="player2Selected" [groups]="groups"
+    [isGroupKnockout]="isGroupKnockoutMode"></app-manual-points>
 </app-modal>

--- a/src/app/components/home.component.scss
+++ b/src/app/components/home.component.scss
@@ -4,21 +4,8 @@
         margin-top: 4.6em;
     }
 }
-.buttons-home-matches {
-    p {
-        color: rgb(141, 142, 142);
-    }
-}
 .wrapper {
     display: flex;
     flex-direction: column;
     gap: 1.5em;
-}
-
-.league-wrapper {
-    display: flex;
-    flex-direction: column;
-    gap: 1.5em;
-    padding-top: 1em;
-    padding-bottom: 5em
 }

--- a/src/app/components/home.component.ts
+++ b/src/app/components/home.component.ts
@@ -1,5 +1,4 @@
 import { Component } from '@angular/core';
-import { MatchesComponent } from './matches/matches.component';
 import { CompetitionMode, IMatch } from '../interfaces/matchesInterfaces';
 import { DataService } from '../../services/data.service';
 import { AddMatchModalComponent } from './add-match-modal/add-match-modal.component';
@@ -10,7 +9,6 @@ import { CommonModule } from '@angular/common';
 import { MODALS, MSG_TYPE } from '../utils/enum';
 import { TranslatePipe } from '../utils/translate.pipe';
 import { BottomNavbarComponent } from '../common/bottom-navbar/bottom-navbar.component';
-import { StatsComponent } from '../common/stats/stats.component';
 import { inject } from '@angular/core';
 import { UserService } from '../../services/user.service';
 import { CompetitionService } from '../../services/competitions.service';
@@ -24,6 +22,8 @@ import { ICompetition } from '../../api/competition.api';
 import { Router } from '@angular/router';
 import { GroupKnockoutComponent } from './group-knockout/group-knockout.component';
 import { Group, KnockoutStageData, mapGroupPlayerToIPlayer } from '../interfaces/group.interface';
+import { LeagueBoardComponent } from './home/league-board/league-board.component';
+import { AddGroupMatchModalComponent } from './add-match-modal/add-group-match-modal/add-group-match-modal.component';
 
 type MatchWithContext = IMatch & {
   competitionType?: CompetitionMode;
@@ -34,7 +34,7 @@ type MatchWithContext = IMatch & {
 
 @Component({
   selector: 'app-home',
-  imports: [CommonModule, BottomNavbarComponent, MatchesComponent, AddMatchModalComponent, ModalComponent, ShowMatchModalComponent, TranslatePipe, StatsComponent, ManualPointsComponent, EliminationBracketComponent, GroupKnockoutComponent],
+  imports: [CommonModule, BottomNavbarComponent, AddMatchModalComponent, ModalComponent, ShowMatchModalComponent, TranslatePipe, ManualPointsComponent, EliminationBracketComponent, GroupKnockoutComponent, LeagueBoardComponent, AddGroupMatchModalComponent],
   templateUrl: './home.component.html',
   styleUrl: './home.component.scss'
 })

--- a/src/app/components/home/league-board/league-board.component.html
+++ b/src/app/components/home/league-board/league-board.component.html
@@ -1,0 +1,39 @@
+<div class="league-wrapper">
+  <p *ngIf="!hasMatches" class="mt-4 text-center">
+    {{ 'matches_not_found' | translate }}
+  </p>
+
+  <section>
+    <app-matches *ngIf="hasMatches" [matches]="matches" (matchEmitter)="onMatchSelected($event)">
+    </app-matches>
+    <div class="buttons-home-matches">
+      <div class="button-container mt-3">
+        <button type="button" (click)="modalService.openModal(modalService.MODALS['ADD_MATCH'])"
+          class="add-match p-2 text-center">
+          {{ 'add_match' | translate }}
+          <span class="m-1"></span>
+          <i class="fa fa-file-text-o" aria-hidden="true"></i>
+        </button>
+        <p class="small text-center mt-3">
+          {{ 'add_match_description' | translate }}
+        </p>
+      </div>
+      <div class="button-container">
+        <div>
+          <button type="button" class="bg-secondary position-relative p-2 text-center"
+            (click)="modalService.openModal(modalService.MODALS['MANUAL_POINTS'])">
+            {{ 'add_manual_set_points' | translate }}
+            <div class="circle-live"></div>
+          </button>
+        </div>
+        <p class="small text-center mt-3">
+          {{ 'add_manual_set_points_description' | translate }}
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <app-stats *ngIf="hasMatches"></app-stats>
+  </section>
+</div>

--- a/src/app/components/home/league-board/league-board.component.scss
+++ b/src/app/components/home/league-board/league-board.component.scss
@@ -1,0 +1,19 @@
+@use '../../../../style/variables.scss' as *;
+
+:host {
+  display: block;
+}
+
+.league-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5em;
+  padding-top: 1em;
+  padding-bottom: 5em;
+}
+
+.buttons-home-matches {
+  p {
+    color: rgb(141, 142, 142);
+  }
+}

--- a/src/app/components/home/league-board/league-board.component.ts
+++ b/src/app/components/home/league-board/league-board.component.ts
@@ -1,0 +1,29 @@
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, Input, Output, inject } from '@angular/core';
+import { MatchesComponent } from '../../matches/matches.component';
+import { ModalService } from '../../../../services/modal.service';
+import { TranslatePipe } from '../../../utils/translate.pipe';
+import { StatsComponent } from '../../../common/stats/stats.component';
+import { IMatch } from '../../../interfaces/matchesInterfaces';
+
+@Component({
+  selector: 'app-league-board',
+  standalone: true,
+  imports: [CommonModule, MatchesComponent, TranslatePipe, StatsComponent],
+  templateUrl: './league-board.component.html',
+  styleUrl: './league-board.component.scss'
+})
+export class LeagueBoardComponent {
+  @Input() matches: IMatch[] = [];
+  @Output() matchSelected = new EventEmitter<IMatch>();
+
+  modalService = inject(ModalService);
+
+  onMatchSelected(match: IMatch) {
+    this.matchSelected.emit(match);
+  }
+
+  get hasMatches(): boolean {
+    return this.matches.length > 0;
+  }
+}

--- a/src/app/interfaces/group.interface.ts
+++ b/src/app/interfaces/group.interface.ts
@@ -9,7 +9,7 @@ export interface Group {
 }
 
 export interface GroupPlayer {
-  playerId: string;
+  id: string;
   name: string;
   surname?: string;
   nickname?: string;
@@ -33,7 +33,7 @@ export interface KnockoutStageData {
 
 export function mapGroupPlayerToIPlayer(player: GroupPlayer): IPlayer {
   return {
-    id: Number(player.playerId),
+    id: Number(player.id),
     name: player.name,
     lastname: player.surname,
     nickname: player.nickname,


### PR DESCRIPTION
## Summary
- refactor the home view to route each competition type through dedicated standalone components and keep the root template focused on the switch
- introduce a league board component and a group-specific add match modal with step indicator-driven flow and group-aware player filtering
- update the manual points modal to support grouped competitions with an added group selection step and shared step indicator UX

## Testing
- npm run lint *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68d7aa51ae948322ba2b76dc881ff077