### PR TITLE
Enhance competition modal presentation

### DIFF
--- a/src/app/components/competitions/competition-detail/competition-detail.component.ts
+++ b/src/app/components/competitions/competition-detail/competition-detail.component.ts
@@ -28,7 +28,7 @@ export class CompetitionDetailComponent {
     console.log('Competition input changed:', this.competition);
   }
   @Output() actionSelected = new EventEmitter<{ action: string, competition: ICompetition | null }>();
-
+  @Output() changeCompetitionSelected = new EventEmitter<ICompetition>();
   copied: boolean = false;
   private competitionService = inject(CompetitionService);
   activeCompetition$ = this.competitionService.activeCompetition$;
@@ -40,11 +40,16 @@ export class CompetitionDetailComponent {
 
   ngOnInit() {
     console.log('CompetitionDetailComponent initialized with competition:', this.competition?.id);
+    this.activeCompetition$.subscribe(comp => {
+      console.log('Active competition updated:', comp);
+      this.competition = comp;
+    });
   }
 
   isEmpty(array: any): boolean {
     return !array || (Array.isArray(array) && array.length === 0);
   }
+  
   onDropdownAction(action: string) {
     if (!this.competition?.id) {
       return;
@@ -60,6 +65,7 @@ export class CompetitionDetailComponent {
         });
         break;
       case 'details':
+        this.changeCompetitionSelected.emit(this.competition);
         this.modalService.openModal(this.detailsModalName);
         break;
       case 'edit':

--- a/src/app/components/competitions/competitions/competitions.component.html
+++ b/src/app/components/competitions/competitions/competitions.component.html
@@ -121,7 +121,7 @@
         <app-edit-competition-modal></app-edit-competition-modal>
     </app-modal>
 
-    <app-modal [transparent]="true" [isSmall]="true" [label]="''"
+    <app-modal [isSmall]="false" [label]="''"
         *ngIf="modalService.isActiveModal(modalService.MODALS['VIEW_COMPETITION'])"
         [modalName]="modalService.MODALS['VIEW_COMPETITION']">
         <app-view-competition-modal [competition]="competitionDetail"></app-view-competition-modal>

--- a/src/app/components/competitions/competitions/competitions.component.html
+++ b/src/app/components/competitions/competitions/competitions.component.html
@@ -11,7 +11,7 @@
         <!-- Dettaglio competizione attiva -->
         <ng-container *ngIf="activeCompetition$ | async as activeCompetition">
             <section *ngIf="activeCompetition">
-                <app-competition-detail [competition]="activeCompetition"></app-competition-detail>
+                <app-competition-detail [competition]="activeCompetition" (changeCompetitionSelected)="updateCompetitionDetail($event)"></app-competition-detail>
             </section>
         </ng-container>
 

--- a/src/app/components/competitions/competitions/competitions.component.ts
+++ b/src/app/components/competitions/competitions/competitions.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, ViewChild } from '@angular/core';
+import { ChangeDetectorRef, Component, inject, ViewChild } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup, FormsModule } from '@angular/forms';
 import { combineLatest, map } from 'rxjs';
 import { SHARED_IMPORTS } from '../../../common/imports/shared.imports';
@@ -63,15 +63,16 @@ export class CompetitionsComponent {
   constructor(
     public modalService: ModalService,
     private fb: FormBuilder,
+    private cdr: ChangeDetectorRef
+
   ) {
     this.createForm();
   }
 
-  ngOnInit() {
-    this.competitionService.getCompetitions().then((data) => {
-      this.competitionDetail = data[0];
-      console.log('[Competitions] competitions loaded', data);
-    });
+  async ngOnInit() {
+    const data = await this.competitionService.getCompetitions();
+    this.competitionDetail = { ...data[0] };
+    this.cdr.detectChanges();
   }
 
   createForm() {
@@ -98,8 +99,8 @@ export class CompetitionsComponent {
 
     switch (action) {
       case 'edit':
+        this.competitionDetail = { ...competition };
         this.modalService.openModal('editCompetitionModal');
-        this.competitionDetail = competition;
         break;
       case 'favorite':
         this.competitionService.updateActiveCompetition(competition.id).subscribe();
@@ -110,8 +111,8 @@ export class CompetitionsComponent {
         });
         break;
       case 'details':
+        this.competitionDetail = { ...competition };
         this.modalService.openModal('viewCompetitionModal');
-        this.competitionDetail = competition;
         break;
     }
   }
@@ -130,5 +131,9 @@ export class CompetitionsComponent {
   }
   onDeleteCancelled() {
     this.modalService.closeModal();
+  }
+  updateCompetitionDetail(competition: ICompetition) {
+    this.competitionDetail = { ...competition };
+    this.cdr.detectChanges();
   }
 }

--- a/src/app/components/competitions/competitions/view-competition-modal/view-competition-modal.component.html
+++ b/src/app/components/competitions/competitions/view-competition-modal/view-competition-modal.component.html
@@ -1,52 +1,84 @@
-<div class="summary">
+<div class="summary competition-modal animate-in">
+  <div class="modal-heading">
     <h3>{{ competition?.name }}</h3>
-    <ul>
-        <li>
-            <span>{{ "best_of" | translate }}</span>
-            <span>{{ competition?.['sets_type'] }}</span>
-        </li>
-        <li>
-            <span>{{ "points_number" | translate }}</span>
-            <span>{{ competition?.['points_type'] }}</span>
-        </li>
-        <li>
-            <span>{{ "type" | translate }}</span>
-            <span class="competition-type">
-                {{ ('competition_type_' + (competition?.type || 'league')) | translate }}
-                <i [ngClass]="['fa-solid', getCompetitionTypeIcon(competition?.type)]"></i>
-            </span>
-        </li>
-        <li *ngIf="competition?.management !== 'admin'">
-            <span>{{ "invitation_code" | translate }}</span>
-            <span class="code">{{ competition?.['code'] }}</span>
-        </li>
-        <li>
-            <span>{{ "players" | translate }}</span>
-            <span>
-                <ng-container *ngIf="!isEmpty(competition?.['players']); else noPlayers">
-                    <span *ngFor="let p of competition?.['players']; let last = last">
-                        {{ p.nickname }}<span *ngIf="!last">, </span>
-                    </span>
-                </ng-container>
-                <ng-template #noPlayers>
-                    {{ "no_players" | translate }}
-                </ng-template>
-            </span>
-        </li>
-    </ul>
-    <div class="d-flex justify-content-center mt-3">
-        <div class="button-container">
-            <button type="button" class="cancel" (click)="modalService.closeModal()">
-                {{ "close" | translate }}
-            </button>
-        </div>
-        <div class="button-container d-flex justify-content-center">
-            <button type="button" class="button-primary-ping" id="add-players-button"
-                (click)="modalService.openModal(modalService.MODALS['ADD_PLAYERS'])">
-                {{ "add_players" | translate }}
-                <i class="fa-solid fa-users ms-2"></i>
-                <i class="fa-solid fa-plus"></i>
-            </button>
-        </div>
+    <p class="meta-created" *ngIf="competition?.created_at">
+      {{ competition?.created_at | date: 'medium' }}
+    </p>
+  </div>
+
+  <div class="meta-grid">
+    <div class="meta-item">
+      <span class="meta-icon" aria-hidden="true">🏆</span>
+      <div class="meta-content">
+        <span class="label">{{ "best_of" | translate }}</span>
+        <span class="value">{{ competition?.['sets_type'] }}</span>
+      </div>
     </div>
+
+    <div class="meta-item">
+      <span class="meta-icon" aria-hidden="true">🎯</span>
+      <div class="meta-content">
+        <span class="label">{{ "points_number" | translate }}</span>
+        <span class="value">{{ competition?.['points_type'] }}</span>
+      </div>
+    </div>
+
+    <div class="meta-item">
+      <span class="meta-icon" aria-hidden="true">📂</span>
+      <div class="meta-content">
+        <span class="label">{{ "type" | translate }}</span>
+        <span class="value competition-type">
+          {{ ('competition_type_' + (competition?.type || 'league')) | translate }}
+          <i [ngClass]="['fa-solid', getCompetitionTypeIcon(competition?.type)]"></i>
+        </span>
+      </div>
+    </div>
+
+    <div class="meta-item" *ngIf="competition?.['admin']">
+      <span class="meta-icon" aria-hidden="true">👤</span>
+      <div class="meta-content">
+        <span class="label">{{ "admin" | translate }}</span>
+        <span class="value">{{ competition?.['admin']?.nickname || competition?.['admin']?.name }}</span>
+      </div>
+    </div>
+
+    <div class="meta-item" *ngIf="competition?.management !== 'admin'">
+      <span class="meta-icon" aria-hidden="true">🔐</span>
+      <div class="meta-content">
+        <span class="label">{{ "invitation_code" | translate }}</span>
+        <span class="value code">{{ competition?.['code'] }}</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="players-section">
+    <div class="section-header">
+      <h4>{{ "players" | translate }}</h4>
+    </div>
+
+    <ng-container *ngIf="!isEmpty(competition?.['players']); else noPlayers">
+      <div class="players-grid">
+        <div class="player-card" *ngFor="let p of competition?.['players']">
+          <div class="player-avatar" aria-hidden="true">
+            {{ p.nickname | slice:0:2 | uppercase }}
+          </div>
+          <span class="player-nickname">{{ p.nickname }}</span>
+        </div>
+      </div>
+    </ng-container>
+    <ng-template #noPlayers>
+      <p class="empty-state">{{ "no_players" | translate }}</p>
+    </ng-template>
+  </div>
+
+  <div class="actions">
+    <button type="button" class="cta button-primary-ping" id="add-players-button"
+      (click)="modalService.openModal(modalService.MODALS['ADD_PLAYERS'])">
+      <i class="fa-solid fa-user-plus"></i>
+      <span>+ {{ "add_players" | translate }}</span>
+    </button>
+    <button type="button" class="cancel" (click)="modalService.closeModal()">
+      {{ "close" | translate }}
+    </button>
+  </div>
 </div>

--- a/src/app/components/competitions/competitions/view-competition-modal/view-competition-modal.component.html
+++ b/src/app/components/competitions/competitions/view-competition-modal/view-competition-modal.component.html
@@ -59,8 +59,8 @@
     <ng-container *ngIf="!isEmpty(competition?.['players']); else noPlayers">
       <div class="players-grid">
         <div class="player-card" *ngFor="let p of competition?.['players']">
-          <div class="player-avatar" aria-hidden="true">
-            {{ p.nickname | slice:0:2 | uppercase }}
+          <div class="player-avatar" aria-hidden="true" [ngStyle]="{'background-image': 'url(' + (p.image_url || '/default-player.jpg') + ')'}">
+            {{ p.nickname | slice:0:2 | uppercase }} 
           </div>
           <span class="player-nickname">{{ p.nickname }}</span>
         </div>

--- a/src/app/components/competitions/competitions/view-competition-modal/view-competition-modal.component.scss
+++ b/src/app/components/competitions/competitions/view-competition-modal/view-competition-modal.component.scss
@@ -1,0 +1,247 @@
+.summary.competition-modal {
+  background: linear-gradient(145deg, #0f172a, #1e293b);
+  color: #e2e8f0;
+  border-radius: 20px;
+  padding: 2rem;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.45);
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  min-width: 0;
+}
+
+.animate-in {
+  animation: fadeIn 320ms ease-out;
+}
+
+.modal-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  text-align: center;
+
+  h3 {
+    margin: 0;
+    font-size: clamp(1.5rem, 2vw + 1rem, 2.25rem);
+    font-weight: 700;
+    color: #f8fafc;
+  }
+
+  .meta-created {
+    margin: 0;
+    color: rgba(226, 232, 240, 0.7);
+    font-size: 0.85rem;
+  }
+}
+
+.meta-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.meta-item {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  background: rgba(15, 23, 42, 0.65);
+  border-radius: 16px;
+  padding: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  transition: transform 200ms ease, box-shadow 200ms ease;
+
+  &:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 12px 30px rgba(15, 23, 42, 0.35);
+  }
+}
+
+.meta-icon {
+  font-size: 1.75rem;
+  line-height: 1;
+}
+
+.meta-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+
+  .label {
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    color: rgba(148, 163, 184, 0.85);
+  }
+
+  .value {
+    font-size: 1rem;
+    font-weight: 600;
+    color: #f1f5f9;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+
+    &.competition-type i {
+      color: #38bdf8;
+      font-size: 1.1rem;
+    }
+
+    &.code {
+      font-family: 'Fira Code', 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+      letter-spacing: 0.08em;
+    }
+  }
+}
+
+.players-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  h4 {
+    margin: 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: #cbd5f5;
+  }
+}
+
+.players-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 1.25rem;
+}
+
+.player-card {
+  background: rgba(30, 41, 59, 0.75);
+  border-radius: 18px;
+  padding: 1.25rem 0.75rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06), 0 10px 20px rgba(15, 23, 42, 0.35);
+  transition: transform 200ms ease, box-shadow 200ms ease;
+
+  &:hover {
+    transform: translateY(-6px) scale(1.01);
+    box-shadow: 0 18px 35px rgba(15, 23, 42, 0.45);
+  }
+}
+
+.player-avatar {
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, rgba(74, 222, 128, 0.4), rgba(34, 197, 94, 0.9));
+  color: #0f172a;
+  font-weight: 700;
+  font-size: 1.25rem;
+  text-transform: uppercase;
+  box-shadow: 0 12px 25px rgba(34, 197, 94, 0.35);
+}
+
+.player-nickname {
+  font-weight: 600;
+  color: #f8fafc;
+  text-align: center;
+  max-width: 100%;
+}
+
+.empty-state {
+  margin: 0;
+  text-align: center;
+  padding: 1.25rem;
+  border-radius: 16px;
+  background: rgba(30, 41, 59, 0.6);
+  border: 1px dashed rgba(148, 163, 184, 0.4);
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.actions button {
+  border-radius: 999px;
+  padding: 0.9rem 1.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  transition: transform 200ms ease, box-shadow 200ms ease;
+}
+
+.actions .cta {
+  background: linear-gradient(135deg, #22c55e, #16a34a);
+  color: #0f172a;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  box-shadow: 0 20px 40px rgba(34, 197, 94, 0.35);
+
+  &:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 24px 45px rgba(34, 197, 94, 0.45);
+  }
+}
+
+.actions .cancel {
+  background: rgba(239, 68, 68, 0.1);
+  color: #fca5a5;
+  border: 1px solid rgba(248, 113, 113, 0.45);
+
+  &:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 20px 35px rgba(248, 113, 113, 0.25);
+    background: rgba(239, 68, 68, 0.2);
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 600px) {
+  .summary.competition-modal {
+    padding: 1.5rem;
+    gap: 1.5rem;
+  }
+
+  .meta-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .players-grid {
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  }
+
+  .actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .actions button {
+    width: 100%;
+    justify-content: center;
+  }
+}

--- a/src/app/components/competitions/competitions/view-competition-modal/view-competition-modal.component.scss
+++ b/src/app/components/competitions/competitions/view-competition-modal/view-competition-modal.component.scss
@@ -1,5 +1,6 @@
+@use '../../../../../style/variables.scss' as *;
+
 .summary.competition-modal {
-  background: linear-gradient(145deg, #0f172a, #1e293b);
   color: #e2e8f0;
   border-radius: 20px;
   padding: 2rem;
@@ -143,12 +144,13 @@
   border-radius: 50%;
   display: grid;
   place-items: center;
-  background: linear-gradient(135deg, rgba(74, 222, 128, 0.4), rgba(34, 197, 94, 0.9));
-  color: #0f172a;
+  color: white;
+  text-shadow: 1px 1px 4px #000000b0;
   font-weight: 700;
   font-size: 1.25rem;
   text-transform: uppercase;
-  box-shadow: 0 12px 25px rgba(34, 197, 94, 0.35);
+  background-size: cover;
+
 }
 
 .player-nickname {
@@ -173,41 +175,7 @@
   flex-wrap: wrap;
   gap: 1rem;
   justify-content: center;
-}
-
-.actions button {
-  border-radius: 999px;
-  padding: 0.9rem 1.75rem;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  transition: transform 200ms ease, box-shadow 200ms ease;
-}
-
-.actions .cta {
-  background: linear-gradient(135deg, #22c55e, #16a34a);
-  color: #0f172a;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.65rem;
-  box-shadow: 0 20px 40px rgba(34, 197, 94, 0.35);
-
-  &:hover {
-    transform: translateY(-3px);
-    box-shadow: 0 24px 45px rgba(34, 197, 94, 0.45);
-  }
-}
-
-.actions .cancel {
-  background: rgba(239, 68, 68, 0.1);
-  color: #fca5a5;
-  border: 1px solid rgba(248, 113, 113, 0.45);
-
-  &:hover {
-    transform: translateY(-3px);
-    box-shadow: 0 20px 35px rgba(248, 113, 113, 0.25);
-    background: rgba(239, 68, 68, 0.2);
-  }
-}
+} 
 
 @keyframes fadeIn {
   from {
@@ -244,4 +212,11 @@
     width: 100%;
     justify-content: center;
   }
+}
+.summary {
+    position: relative;
+    background: transparent;
+    filter: none;
+    box-shadow: none;
+    border: none;
 }

--- a/src/app/components/competitions/competitions/view-competition-modal/view-competition-modal.component.ts
+++ b/src/app/components/competitions/competitions/view-competition-modal/view-competition-modal.component.ts
@@ -20,6 +20,7 @@ export class ViewCompetitionModalComponent {
 
   ngOnInit() {
     console.log('CompetitionDetailComponent initialized with competition:', this.competition?.id);
+    console.log('competition players', this.competition?.players);
   }
 
   isEmpty(array: any): boolean {

--- a/src/style/style.scss
+++ b/src/style/style.scss
@@ -277,9 +277,6 @@ section {
         background: #ffffff00;
         box-shadow: none;
         overflow: hidden;
-        .close {
-            visibility: hidden;
-        }
     }
 
     .modal-content {


### PR DESCRIPTION
## Summary
- restyle the competition modal with descriptive icons and responsive layout improvements
- present players as modern avatar cards with emphasized call-to-action for adding participants
- refresh dark theme details with rounded surfaces, shadows, and fade-in animation

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68d7c0bc086c83228072e2b5749d6a9d