### PR TITLE
Add unit tests for core components and services

### DIFF
--- a/src/app/components/add-match-modal/add-match-modal.component.spec.ts
+++ b/src/app/components/add-match-modal/add-match-modal.component.spec.ts
@@ -1,0 +1,153 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { AddMatchModalComponent } from './add-match-modal.component';
+import { ModalService } from '../../../services/modal.service';
+import { DataService } from '../../../services/data.service';
+import { LoaderService } from '../../../services/loader.service';
+import { TranslationService } from '../../../services/translation.service';
+import { CompetitionService } from '../../../services/competitions.service';
+import { BehaviorSubject } from 'rxjs';
+import { FormBuilder } from '@angular/forms';
+import { MSG_TYPE } from '../../utils/enum';
+
+class ModalServiceStub {
+  closeModal = jasmine.createSpy('closeModal');
+  openManualPointsEvent = jasmine.createSpy('openManualPointsEvent');
+}
+
+class DataServiceStub {
+  addMatch = jasmine.createSpy('addMatch').and.returnValue(Promise.resolve());
+  getLoggedInPlayerId = jasmine.createSpy('getLoggedInPlayerId').and.returnValue(99);
+}
+
+class LoaderServiceStub {
+  showToast = jasmine.createSpy('showToast');
+  addSpinnerToButton = jasmine.createSpy('addSpinnerToButton');
+  removeSpinnerFromButton = jasmine.createSpy('removeSpinnerFromButton');
+}
+
+class TranslationServiceStub {
+  translate(key: string) {
+    return `translated:${key}`;
+  }
+}
+
+class CompetitionServiceStub {
+  activeCompetition$ = new BehaviorSubject<any>(null);
+}
+
+describe('AddMatchModalComponent', () => {
+  let component: AddMatchModalComponent;
+  let fixture: ComponentFixture<AddMatchModalComponent>;
+  let dataService: DataServiceStub;
+  let loaderService: LoaderServiceStub;
+  let competitionService: CompetitionServiceStub;
+  let modalService: ModalServiceStub;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AddMatchModalComponent],
+      providers: [
+        { provide: ModalService, useClass: ModalServiceStub },
+        { provide: DataService, useClass: DataServiceStub },
+        { provide: LoaderService, useClass: LoaderServiceStub },
+        { provide: TranslationService, useClass: TranslationServiceStub },
+        { provide: CompetitionService, useClass: CompetitionServiceStub },
+        FormBuilder,
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AddMatchModalComponent);
+    component = fixture.componentInstance;
+    dataService = TestBed.inject(DataService) as unknown as DataServiceStub;
+    loaderService = TestBed.inject(LoaderService) as unknown as LoaderServiceStub;
+    competitionService = TestBed.inject(CompetitionService) as unknown as CompetitionServiceStub;
+    modalService = TestBed.inject(ModalService) as unknown as ModalServiceStub;
+  });
+
+  function initComponent(playersCount = 2) {
+    component.players = Array.from({ length: playersCount }, (_, i) => ({ id: i + 1, name: `Player ${i + 1}` })) as any;
+    component.ngOnInit();
+  }
+
+  it('should warn and close when there are not enough players', () => {
+    initComponent(1);
+    expect(loaderService.showToast).toHaveBeenCalledWith('translated:not_enough_players', MSG_TYPE.WARNING);
+    expect(modalService.closeModal).toHaveBeenCalled();
+  });
+
+  it('should sanitize set scores respecting limits and avoiding duplicates', () => {
+    initComponent();
+    component.competition = { sets_type: 3 } as any;
+    component.matchForm.get('p2Score')?.setValue(3);
+    component.matchForm.get('p1Score')?.setValue('99');
+
+    component.sanitizeInput('p1Score');
+    expect(component.matchForm.get('p1Score')?.value).toBe(2);
+    expect(component.errorsOfSets).toContain('number_maximum 3');
+    expect(component.errorsOfSets).toContain('number_equal');
+  });
+
+  it('should validate points per set and clamp invalid values', () => {
+    initComponent();
+    component.competition = { points_type: 11 } as any;
+    const fb = component['fb'] as FormBuilder;
+    component.setsPoints.push(fb.group({ player1Points: -1, player2Points: 25 }));
+
+    component.checkPointsError();
+    expect(component.errorsOfPoints).toContain('set 1: number_positive_p1');
+    expect(component.errorsOfPoints).toContain('set 1: number_maximum_p2 11');
+    const setGroup = component.getSetFormGroup(0);
+    expect(setGroup.value.player1Points).toBe(0);
+    expect(setGroup.value.player2Points).toBe(11);
+  });
+
+  it('should filter available players based on group selection and logged user', () => {
+    initComponent();
+    component.groups = [{ id: 'g1', players: [{ id: 2 }, { id: 3 }] }] as any;
+    component.competition = { type: 'group_knockout' } as any;
+    component.matchForm.patchValue({ player1: 2, player2: 3 });
+    component.matchForm.get('groupId')?.setValue('g1');
+    dataService.getLoggedInPlayerId.and.returnValue(1);
+
+    const players = component.getPlayers(1);
+    expect(players.map(p => p.id)).toEqual([2]);
+  });
+
+  it('should update form when competition configuration changes', () => {
+    initComponent();
+    competitionService.activeCompetition$.next({ id: 1, type: 'group_knockout', points_type: 21, sets_type: 7 } as any);
+    expect(component.maxPoints).toBe(21);
+    expect(component.maxSets).toBe(7);
+    expect(component.matchForm.get('groupId')?.hasError('required')).toBeTrue();
+
+    competitionService.activeCompetition$.next({ id: 1, type: 'league', points_type: 11, sets_type: 5 } as any);
+    expect(component.matchForm.get('groupId')?.hasError('required')).toBeFalse();
+  });
+
+  it('should prevent match with identical players', fakeAsync(() => {
+    initComponent();
+    spyOn(window, 'alert');
+    component.matchForm.patchValue({ player1: 2, player2: 2, p1Score: 1, p2Score: 0 });
+
+    component.addMatch();
+    tick();
+
+    expect(window.alert).toHaveBeenCalled();
+    expect(dataService.addMatch).not.toHaveBeenCalled();
+  }));
+
+  it('should submit match data and close modal', async () => {
+    initComponent();
+    competitionService.activeCompetition$.next({ id: 1, type: 'league', points_type: 11, sets_type: 5 } as any);
+    component.matchForm.patchValue({ player1: 1, player2: 2, p1Score: 2, p2Score: 1 });
+
+    await component.addMatch();
+
+    expect(dataService.addMatch).toHaveBeenCalled();
+    const payload = dataService.addMatch.calls.mostRecent().args[0];
+    expect(payload.player1).toBe(1);
+    expect(payload.player2).toBe(2);
+    expect(payload.setsPoints).toEqual([]);
+    expect(modalService.closeModal).toHaveBeenCalled();
+  });
+});

--- a/src/app/components/landing/landing.component.spec.ts
+++ b/src/app/components/landing/landing.component.spec.ts
@@ -1,0 +1,34 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { LandingComponent } from './landing.component';
+
+describe('LandingComponent', () => {
+  let component: LandingComponent;
+  let fixture: ComponentFixture<LandingComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LandingComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LandingComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should define default highlights with translation keys', () => {
+    expect(component.highlights.length).toBe(3);
+    expect(component.highlights[0]).toEqual(jasmine.objectContaining({
+      title: 'highlight1_title',
+      description: 'highlight1_desc',
+      icon: 'fa-trophy',
+    }));
+  });
+
+  it('should expose testimonials for landing page', () => {
+    expect(component.testimonials.length).toBeGreaterThan(0);
+    expect(component.testimonials[0]).toEqual(jasmine.objectContaining({
+      quote: 'testimonial1_quote',
+      name: 'testimonial1_name',
+      role: 'testimonial1_role',
+    }));
+  });
+});

--- a/src/app/components/matches/matches.component.spec.ts
+++ b/src/app/components/matches/matches.component.spec.ts
@@ -1,0 +1,82 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatchesComponent } from './matches.component';
+import { ModalService } from '../../../services/modal.service';
+import { Utils } from '../../utils/Utils';
+import { ElementRef } from '@angular/core';
+
+class ModalServiceStub {
+  MODALS = { SHOW_MATCH: 'SHOW_MATCH' } as const;
+  openModal = jasmine.createSpy('openModal');
+}
+
+describe('MatchesComponent', () => {
+  let component: MatchesComponent;
+  let fixture: ComponentFixture<MatchesComponent>;
+  let modalService: ModalServiceStub;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatchesComponent],
+      providers: [{ provide: ModalService, useClass: ModalServiceStub }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MatchesComponent);
+    component = fixture.componentInstance;
+    modalService = TestBed.inject(ModalService) as unknown as ModalServiceStub;
+    component.matchesSlider = new ElementRef(document.createElement('div'));
+  });
+
+  it('should limit matches returned and reverse when requested', () => {
+    component.matches = Array.from({ length: 30 }, (_, i) => ({ id: String(i), value: i }));
+    component.maxMatchesToShow = 5;
+
+    const normalOrder = component.getMatchesToRender();
+    expect(normalOrder.length).toBe(5);
+    expect(normalOrder[0].id).toBe('0');
+
+    const reversed = component.getMatchesToRender(true);
+    expect(reversed[0].id).toBe('29');
+  });
+
+  it('should return empty array when no matches provided', () => {
+    component.matches = undefined as any;
+    expect(component.getMatchesToRender()).toEqual([]);
+  });
+
+  it('should ignore click when slider was just dragged', () => {
+    spyOn(Utils, 'isMobile').and.returnValue(false);
+    component.slider = { justDragged: true } as any;
+    component.matches = [{ id: '1', player1: 'A' }];
+    spyOn(component.matchEmitter, 'emit');
+
+    component.onMatchClick('1');
+    expect(component.matchEmitter.emit).not.toHaveBeenCalled();
+    expect(modalService.openModal).not.toHaveBeenCalled();
+  });
+
+  it('should emit match selection and open modal', () => {
+    spyOn(Utils, 'isMobile').and.returnValue(false);
+    component.slider = { justDragged: false } as any;
+    const match = { id: '2', player1: 'A' } as any;
+    component.matches = [match];
+    const emitSpy = spyOn(component.matchEmitter, 'emit');
+
+    component.onMatchClick('2');
+    expect(component.clickedMatch).toEqual(match);
+    expect(emitSpy).toHaveBeenCalledWith(match);
+    expect(modalService.openModal).toHaveBeenCalledWith(modalService.MODALS.SHOW_MATCH);
+  });
+
+  it('should fallback to default image on error', () => {
+    const img = document.createElement('img');
+    const event = new Event('error');
+    Object.defineProperty(event, 'target', { value: img });
+
+    component.onImageError(event);
+    expect(img.src).toContain('/default-player.jpg');
+  });
+
+  it('should track items by index', () => {
+    expect(component.trackByIndex(3, { id: 3 })).toBe(3);
+  });
+});

--- a/src/services/auth.service.spec.ts
+++ b/src/services/auth.service.spec.ts
@@ -1,0 +1,63 @@
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { AuthService } from './auth.service';
+import { SupabaseAuthService } from './supabase-auth.service';
+import { UserService } from './user.service';
+import { CompetitionService } from './competitions.service';
+
+class SupabaseAuthServiceStub {
+  getUserSession = jasmine.createSpy('getUserSession').and.returnValue(Promise.resolve({ data: { session: null } }));
+  signOut = jasmine.createSpy('signOut').and.returnValue(Promise.resolve());
+}
+
+class UserServiceStub {
+  clear = jasmine.createSpy('clear');
+}
+
+class CompetitionServiceStub {}
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let supabase: SupabaseAuthServiceStub;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        AuthService,
+        { provide: SupabaseAuthService, useClass: SupabaseAuthServiceStub },
+        { provide: UserService, useClass: UserServiceStub },
+        { provide: CompetitionService, useClass: CompetitionServiceStub },
+      ],
+    });
+
+    service = TestBed.inject(AuthService);
+    supabase = TestBed.inject(SupabaseAuthService) as unknown as SupabaseAuthServiceStub;
+  });
+
+  it('should mark user as logged in when session exists', fakeAsync(() => {
+    supabase.getUserSession.and.returnValue(Promise.resolve({ data: { session: { user: {} } } }));
+
+    service.checkAuth();
+    tick();
+
+    let latest = false;
+    service.isLoggedIn$.subscribe(value => (latest = value));
+    tick();
+    expect(latest).toBeTrue();
+  }));
+
+  it('should logout and clear user data', fakeAsync(() => {
+    const userService = TestBed.inject(UserService) as unknown as UserServiceStub;
+
+    service.isLoggedIn$.next(true);
+    service.logout();
+    tick();
+
+    expect(supabase.signOut).toHaveBeenCalled();
+    expect(userService.clear).toHaveBeenCalled();
+
+    let latest = true;
+    service.isLoggedIn$.subscribe(value => (latest = value));
+    tick();
+    expect(latest).toBeFalse();
+  }));
+});

--- a/src/services/competitions.service.spec.ts
+++ b/src/services/competitions.service.spec.ts
@@ -1,0 +1,161 @@
+import { TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+import { CompetitionService } from './competitions.service';
+import { CompetitionApi, ICompetition } from '../api/competition.api';
+import { CompetitionStore } from '../stores/competition.store';
+import { LoaderService } from './loader.service';
+import { MSG_TYPE } from '../app/utils/enum';
+import { UserService } from './user.service';
+
+class CompetitionApiStub {
+  getList = jasmine.createSpy('getList').and.returnValue(of({ competitions: [] }));
+  join = jasmine.createSpy('join').and.returnValue(of({ competition: null, user_state: null }));
+}
+
+class CompetitionStoreStub {
+  list$ = of([]);
+  activeCompetition$ = of(null);
+  private list: ICompetition[] = [];
+  private activeId: string | null = null;
+
+  snapshotList(): ICompetition[] {
+    return [...this.list];
+  }
+
+  snapshotActive(): ICompetition | null {
+    if (!this.activeId) return null;
+    return this.list.find(c => String(c.id) === this.activeId) ?? null;
+  }
+
+  snapshotById(id: number | string): ICompetition | undefined {
+    return this.list.find(c => String(c.id) === String(id));
+  }
+
+  setList(list: ICompetition[]) {
+    this.list = [...list];
+  }
+
+  addOne(comp: ICompetition) {
+    this.upsertOne(comp, { prepend: true });
+  }
+
+  upsertOne(comp: ICompetition, opts?: { prepend?: boolean }) {
+    const idx = this.list.findIndex(c => String(c.id) === String(comp.id));
+    if (idx >= 0) {
+      this.list[idx] = { ...this.list[idx], ...comp };
+    } else if (opts?.prepend) {
+      this.list = [comp, ...this.list];
+    } else {
+      this.list = [...this.list, comp];
+    }
+  }
+
+  removeOne(id: number | string) {
+    const strId = String(id);
+    this.list = this.list.filter(c => String(c.id) !== strId);
+    if (this.activeId === strId) {
+      this.activeId = null;
+    }
+  }
+
+  clear() {
+    this.list = [];
+    this.activeId = null;
+  }
+
+  setActive(id: number | string | null) {
+    this.activeId = id !== null ? String(id) : null;
+  }
+}
+
+class LoaderServiceStub {
+  startLittleLoader = jasmine.createSpy('startLittleLoader');
+  stopLittleLoader = jasmine.createSpy('stopLittleLoader');
+  showToast = jasmine.createSpy('showToast');
+}
+
+class UserServiceStub {
+  private state: any = null;
+  snapshot() {
+    return this.state;
+  }
+  setLocal = jasmine.createSpy('setLocal').and.callFake((state: any) => {
+    this.state = state;
+  });
+  setActiveCompetitionId = jasmine.createSpy('setActiveCompetitionId');
+}
+
+describe('CompetitionService', () => {
+  let service: CompetitionService;
+  let api: CompetitionApiStub;
+  let store: CompetitionStoreStub;
+  let loader: LoaderServiceStub;
+  let user: UserServiceStub;
+
+  const mockCompetition: ICompetition = {
+    id: 1,
+    name: 'Test Cup',
+    type: 'league',
+    setsType: 5,
+    pointsType: 11,
+    management: 'admin',
+  } as ICompetition;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        CompetitionService,
+        { provide: CompetitionApi, useClass: CompetitionApiStub },
+        { provide: CompetitionStore, useClass: CompetitionStoreStub },
+        { provide: LoaderService, useClass: LoaderServiceStub },
+        { provide: UserService, useClass: UserServiceStub },
+      ],
+    });
+
+    service = TestBed.inject(CompetitionService);
+    api = TestBed.inject(CompetitionApi) as unknown as CompetitionApiStub;
+    store = TestBed.inject(CompetitionStore) as unknown as CompetitionStoreStub;
+    loader = TestBed.inject(LoaderService) as unknown as LoaderServiceStub;
+    user = TestBed.inject(UserService) as unknown as UserServiceStub;
+  });
+
+  it('should fetch competitions and cache the result', async () => {
+    api.getList.and.returnValue(of({ competitions: [mockCompetition] }));
+
+    const firstCall = await service.getCompetitions();
+    expect(firstCall).toEqual([mockCompetition]);
+    expect(store.snapshotList()).toEqual([mockCompetition]);
+    expect(loader.stopLittleLoader).toHaveBeenCalled();
+
+    const callsAfterFirst = api.getList.calls.count();
+    const secondCall = await service.getCompetitions();
+    expect(secondCall).toEqual([mockCompetition]);
+    expect(api.getList.calls.count()).toBe(callsAfterFirst);
+  });
+
+  it('should return existing competitions when fetch fails', async () => {
+    store.setList([mockCompetition]);
+    api.getList.and.returnValue(throwError(() => new Error('network')));
+
+    const result = await service.getCompetitions(true);
+    expect(result).toEqual([mockCompetition]);
+    expect(loader.showToast).toHaveBeenCalledWith('Errore nel caricamento competizioni', MSG_TYPE.ERROR);
+    expect(loader.stopLittleLoader).toHaveBeenCalled();
+  });
+
+  it('should resolve active competition from user when store empty', () => {
+    store.setList([mockCompetition]);
+    user.setLocal({ active_competition_id: mockCompetition.id });
+    store.setActive(null);
+
+    const active = service.snapshotActive();
+    expect(active).toEqual(mockCompetition);
+  });
+
+  it('should reject join when user id is undefined', async () => {
+    user.setLocal({ user_id: undefined });
+
+    await expectAsync(service.joinCompetition('ABC')).toBeRejectedWithError('User ID is undefined');
+    expect(loader.startLittleLoader).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/data.service.spec.ts
+++ b/src/services/data.service.spec.ts
@@ -1,0 +1,108 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { DataService } from './data.service';
+import { LoaderService } from './loader.service';
+import { UserService } from './user.service';
+import { RankingService } from './ranking.service';
+import { API_PATHS } from '../api/api.config';
+import { of } from 'rxjs';
+
+class LoaderServiceStub {
+  showToast = jasmine.createSpy('showToast');
+  stopLittleLoader = jasmine.createSpy('stopLittleLoader');
+  startLittleLoader = jasmine.createSpy('startLittleLoader');
+  addSpinnerToButton = jasmine.createSpy('addSpinnerToButton');
+  removeSpinnerFromButton = jasmine.createSpy('removeSpinnerFromButton');
+}
+
+class UserServiceStub {
+  private state: any = { active_competition_id: 1 };
+  snapshot() {
+    return this.state;
+  }
+  setState(state: any) {
+    this.state = state;
+  }
+  getState = jasmine.createSpy('getState').and.callFake(() => of(this.state));
+}
+
+class RankingServiceStub {
+  triggerRefresh = jasmine.createSpy('triggerRefresh');
+}
+
+describe('DataService', () => {
+  let service: DataService;
+  let httpMock: HttpTestingController;
+  let userService: UserServiceStub;
+
+  const mockResponse = {
+    matches: [{ id: 1, player1: 'A', player2: 'B', date: '2023-01-01' }],
+    wins: {},
+    totPlayed: {},
+    points: {},
+    players: [],
+    matchesElimination: [],
+    monthlyWinRates: {},
+    badges: {},
+    giocatore1Score: 0,
+    giocatore2Score: 0,
+  } as any;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        DataService,
+        { provide: LoaderService, useClass: LoaderServiceStub },
+        { provide: UserService, useClass: UserServiceStub },
+        { provide: RankingService, useClass: RankingServiceStub },
+      ],
+    });
+
+    service = TestBed.inject(DataService);
+    httpMock = TestBed.inject(HttpTestingController);
+    userService = TestBed.inject(UserService) as unknown as UserServiceStub;
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should fetch matches and reuse cached data when called twice', async () => {
+    const firstPromise = service.fetchMatches();
+    const req = httpMock.expectOne(r => r.url === API_PATHS.getMatches);
+    expect(req.request.method).toBe('GET');
+    expect(req.request.params.get('competitionId')).toBe('1');
+    req.flush(mockResponse);
+
+    await expectAsync(firstPromise).toBeResolved();
+
+    const second = await service.fetchMatches();
+    expect(second.matches).toEqual(mockResponse.matches);
+    httpMock.expectNone(req => req.url === API_PATHS.getMatches);
+  });
+
+  it('should refetch when active competition changes', async () => {
+    const first = service.fetchMatches();
+    httpMock.expectOne(r => r.url === API_PATHS.getMatches).flush(mockResponse);
+    await expectAsync(first).toBeResolved();
+
+    userService.setState({ active_competition_id: 2 });
+
+    const secondPromise = service.fetchMatches();
+    const req = httpMock.expectOne(r => r.url === API_PATHS.getMatches);
+    expect(req.request.params.get('competitionId')).toBe('2');
+    req.flush(mockResponse);
+    await expectAsync(secondPromise).toBeResolved();
+  });
+
+  it('should reject addMatch when scores missing', async () => {
+    await expectAsync(service.addMatch({ p1Score: null as any, p2Score: null as any })).toBeRejectedWith('Invalid data');
+  });
+
+  it('should return empty groups when no competition selected', async () => {
+    userService.setState({ active_competition_id: null });
+    const groups = await service.fetchGroups();
+    expect(groups).toEqual({ groups: [] });
+  });
+});

--- a/src/services/dropdown.service.spec.ts
+++ b/src/services/dropdown.service.spec.ts
@@ -1,0 +1,43 @@
+import { DropdownService, DropdownAction } from './dropdown.service';
+
+describe('DropdownService', () => {
+  let service: DropdownService;
+
+  beforeEach(() => {
+    service = new DropdownService();
+    DropdownService['isOpen'] = false;
+  });
+
+  it('should open dropdown with provided actions and anchor', () => {
+    const actions: DropdownAction[] = [{ value: 'edit', label: 'Edit' }];
+    const anchor = document.createElement('button');
+
+    let latestState: any = null;
+    service.state$.subscribe(state => (latestState = state));
+
+    service.open(actions, anchor);
+    expect(latestState).toEqual({ actions, anchor });
+    expect(DropdownService['isOpen']).toBeTrue();
+  });
+
+  it('should close dropdown and reset state', () => {
+    service.open([], document.createElement('div'));
+
+    let latestState: any = undefined;
+    service.state$.subscribe(state => (latestState = state));
+
+    service.close();
+    expect(latestState).toBeNull();
+    expect(DropdownService['isOpen']).toBeFalse();
+  });
+
+  it('should emit action value and close dropdown', () => {
+    let emitted: string | null = null;
+    service.action$.subscribe(value => (emitted = value));
+    service.open([], document.createElement('div'));
+
+    service.emit('delete');
+    expect(emitted as unknown as string).toBe('delete');
+    expect(DropdownService['isOpen']).toBeFalse();
+  });
+});

--- a/src/services/loader.service.spec.ts
+++ b/src/services/loader.service.spec.ts
@@ -1,0 +1,72 @@
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { LoaderService } from './loader.service';
+import { MSG_TYPE } from '../app/utils/enum';
+import { TranslationService } from './translation.service';
+import { Utils } from '../app/utils/Utils';
+
+class TranslationServiceStub {
+  translate(key: string): string {
+    return `translated:${key}`;
+  }
+}
+
+describe('LoaderService', () => {
+  let service: LoaderService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        LoaderService,
+        { provide: TranslationService, useClass: TranslationServiceStub },
+      ],
+    });
+    service = TestBed.inject(LoaderService);
+  });
+
+  it('should toggle global loader state', () => {
+    let lastValue = false;
+    service.isLoading$.subscribe(value => (lastValue = value));
+
+    service.startLoader();
+    expect(lastValue).toBeTrue();
+
+    service.stopLoader();
+    expect(lastValue).toBeFalse();
+  });
+
+  it('should add and remove spinner to button element', () => {
+    const button = document.createElement('button');
+
+    service.addSpinnerToButton(button);
+    expect(button.querySelector('.loader-spinner')).not.toBeNull();
+    expect(button.style.opacity).toBe('0.7');
+
+    service.removeSpinnerFromButton(button);
+    expect(button.querySelector('.loader-spinner')).toBeNull();
+    expect(button.style.opacity).toBe('1');
+  });
+
+  it('should emit toast messages translated and clear after duration', fakeAsync(() => {
+    const toastMessages: Array<{ message: string; type: MSG_TYPE } | null> = [];
+    service.toast$.subscribe(value => toastMessages.push(value));
+
+    spyOn(Utils, 'isIos').and.returnValue(false);
+    const highlightTarget = document.createElement('button');
+    highlightTarget.id = 'add-players-button';
+    document.body.appendChild(highlightTarget);
+
+    service.showToast('not_enough_players', MSG_TYPE.WARNING, 1000);
+    expect(toastMessages[toastMessages.length - 1]).toEqual({
+      message: 'translated:not_enough_players',
+      type: MSG_TYPE.WARNING,
+    });
+
+    tick(1000);
+    expect(toastMessages[toastMessages.length - 1]).toBeNull();
+
+    tick(1000);
+    expect(highlightTarget.classList.contains('highlight')).toBeTrue();
+
+    document.body.removeChild(highlightTarget);
+  }));
+});

--- a/src/services/modal.service.spec.ts
+++ b/src/services/modal.service.spec.ts
@@ -1,0 +1,45 @@
+import { ModalService } from './modal.service';
+
+describe('ModalService', () => {
+  let service: ModalService;
+  let wrapper: HTMLElement;
+
+  beforeEach(() => {
+    service = new ModalService();
+    wrapper = document.createElement('div');
+    wrapper.className = 'wrapper';
+    document.body.appendChild(wrapper);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(wrapper);
+  });
+
+  it('should open modal and apply effects', () => {
+    let latest: string | null = null;
+    service.activeModal$.subscribe(value => (latest = value));
+
+    service.openModal('TEST');
+    expect(latest as unknown as string).toBe('TEST');
+    expect(document.querySelector('html')?.style.getPropertyValue('overflow')).toBe('hidden');
+    expect(wrapper.style.filter).toBe('blur(0.625em)');
+  });
+
+  it('should close modal and remove effects', () => {
+    service.openModal('TEST');
+    service.closeModal();
+
+    let latest: string | null = undefined as any;
+    service.activeModal$.subscribe(value => (latest = value));
+
+    expect(latest).toBeNull();
+    expect(document.querySelector('html')?.style.getPropertyValue('overflow')).toBe('');
+    expect(wrapper.style.filter).toBe('');
+  });
+
+  it('should check if modal is active', () => {
+    service.openModal('ACTIVE');
+    expect(service.isActiveModal('ACTIVE')).toBeTrue();
+    expect(service.isActiveModal('OTHER')).toBeFalse();
+  });
+});

--- a/src/services/players.service.spec.ts
+++ b/src/services/players.service.spec.ts
@@ -1,0 +1,36 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { PlayersService } from './players.service';
+import { environment } from '../environments/environment';
+import { API_PATHS } from '../api/api.config';
+
+const apiUrl = environment.apiUrl + API_PATHS.getPlayers;
+
+describe('PlayersService', () => {
+  let service: PlayersService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+    });
+    service = TestBed.inject(PlayersService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should request players list from API', () => {
+    const mockPlayers = [{ id: 1, name: 'Alice' }];
+
+    service.getPlayers().subscribe(players => {
+      expect(players).toEqual(mockPlayers);
+    });
+
+    const req = httpMock.expectOne(apiUrl);
+    expect(req.request.method).toBe('GET');
+    req.flush(mockPlayers);
+  });
+});

--- a/src/services/ranking.service.spec.ts
+++ b/src/services/ranking.service.spec.ts
@@ -1,0 +1,61 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { RankingService } from './ranking.service';
+import { environment } from '../environments/environment';
+import { API_PATHS } from '../api/api.config';
+
+const buildUrl = (competitionId: string) => `${environment.apiUrl}${API_PATHS.getRanking}?competition_id=${competitionId}`;
+
+describe('RankingService', () => {
+  let service: RankingService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+    });
+    service = TestBed.inject(RankingService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should fetch ranking and reuse cached response', async () => {
+    const response = { ranking: [], generatedAt: new Date().toISOString() };
+    const promise = service.getRanking('1');
+
+    const req = httpMock.expectOne(buildUrl('1'));
+    expect(req.request.method).toBe('GET');
+    req.flush(response);
+
+    await expectAsync(promise).toBeResolvedTo(response);
+
+    const second = await service.getRanking('1');
+    expect(second).toEqual(response);
+    httpMock.expectNone(buildUrl('1'));
+  });
+
+  it('should clear cache per competition id', async () => {
+    const response = { ranking: [], generatedAt: new Date().toISOString() };
+
+    const first = service.getRanking('2');
+    httpMock.expectOne(buildUrl('2')).flush(response);
+    await expectAsync(first).toBeResolvedTo(response);
+
+    service.clearRankingCache('2');
+
+    const second = service.getRanking('2');
+    httpMock.expectOne(buildUrl('2')).flush(response);
+    await expectAsync(second).toBeResolvedTo(response);
+  });
+
+  it('should emit refresh notifications', () => {
+    let emitted = false;
+    service.refreshObs$.subscribe(() => (emitted = true));
+
+    service.triggerRefresh();
+    expect(emitted).toBeTrue();
+  });
+});

--- a/src/services/translation.service.spec.ts
+++ b/src/services/translation.service.spec.ts
@@ -1,0 +1,64 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClient } from '@angular/common/http';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { TranslationService } from './translation.service';
+
+describe('TranslationService', () => {
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+    });
+    httpMock = TestBed.inject(HttpTestingController);
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+    sessionStorage.clear();
+  });
+
+  function createService(options: { navigatorLang?: string; savedLanguage?: string | null } = {}): TranslationService {
+    const { navigatorLang = 'en-US', savedLanguage = null } = options;
+
+    Object.defineProperty(window.navigator, 'language', { value: navigatorLang, configurable: true });
+    Object.defineProperty(window.navigator, 'languages', { value: [navigatorLang], configurable: true });
+
+    if (savedLanguage) {
+      sessionStorage.setItem('selectedLanguage', savedLanguage);
+    } else {
+      sessionStorage.removeItem('selectedLanguage');
+    }
+
+    const service = TestBed.runInInjectionContext(() => new TranslationService(TestBed.inject(HttpClient)));
+    const req = httpMock.expectOne('/lang.json');
+    req.flush({
+      greeting: { en: 'Hello', it: 'Ciao' },
+    });
+    return service;
+  }
+
+  it('should fall back to navigator Italian when no saved language exists', () => {
+    const service = createService({ navigatorLang: 'it-IT' });
+    expect(service.getLanguage()).toBe('it');
+  });
+
+  it('should use saved language over navigator preference', () => {
+    const service = createService({ navigatorLang: 'it-IT', savedLanguage: 'en' });
+    expect(service.getLanguage()).toBe('en');
+  });
+
+  it('should set language and persist when manually selected', () => {
+    const service = createService();
+    service.setLanguage('it', true);
+    expect(service.getLanguage()).toBe('it');
+    expect(sessionStorage.getItem('selectedLanguage')).toBe('it');
+  });
+
+  it('should translate keys and fallback when translation missing', () => {
+    const service = createService();
+    expect(service.translate('greeting')).toBe('Hello');
+    expect(service.translate('missing_key')).toBe('missing_key');
+  });
+});

--- a/src/services/user.service.spec.ts
+++ b/src/services/user.service.spec.ts
@@ -1,0 +1,142 @@
+import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { UserService } from './user.service';
+import { UserApi } from '../api/user.api';
+import { UserStore } from '../stores/user.store';
+import { CompetitionStore } from '../stores/competition.store';
+import { IUserState } from './interfaces/Interfaces';
+import { BehaviorSubject } from 'rxjs';
+
+class UserApiStub {
+  getUserState = jasmine.createSpy('getUserState').and.returnValue(of());
+  updateUserState = jasmine.createSpy('updateUserState').and.returnValue(of());
+}
+
+class UserStoreStub {
+  private subject = new BehaviorSubject<IUserState | null>(null);
+  state$ = this.subject.asObservable();
+  setSpy = jasmine.createSpy('set');
+  patchSpy = jasmine.createSpy('patch');
+  clearSpy = jasmine.createSpy('clear');
+
+  snapshot(): IUserState | null {
+    return this.subject.getValue();
+  }
+
+  set(state: IUserState | null) {
+    this.setSpy(state);
+    this.subject.next(state ? { ...state } : null);
+  }
+
+  patch(patch: Partial<IUserState>) {
+    this.patchSpy(patch);
+    const current = this.subject.getValue();
+    if (!current) return;
+    this.subject.next({ ...current, ...patch });
+  }
+
+  clear() {
+    this.clearSpy();
+    this.subject.next(null);
+  }
+}
+
+class CompetitionStoreStub {
+  upsertOne = jasmine.createSpy('upsertOne');
+  setActive = jasmine.createSpy('setActive');
+}
+
+describe('UserService', () => {
+  let service: UserService;
+  let api: UserApiStub;
+  let store: UserStoreStub;
+  let competitionStore: CompetitionStoreStub;
+
+  const baseState: IUserState = {
+    active_competition: { id: 1, name: 'Comp', type: 'league', setsType: 5, pointsType: 11, management: 'admin' } as any,
+    user_state_id: 1,
+    user_id: 'uuid',
+    state: 'profile_completed',
+    active_competition_id: 1,
+    created_at: '2023-01-01',
+    updated_at: '2023-01-02',
+    nickname: 'Player',
+    player_id: 10,
+    image_url: null,
+    email: 'player@example.com',
+    name: 'Name',
+    lastname: 'Last',
+  } as IUserState;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        UserService,
+        { provide: UserApi, useClass: UserApiStub },
+        { provide: UserStore, useClass: UserStoreStub },
+        { provide: CompetitionStore, useClass: CompetitionStoreStub },
+      ],
+    });
+
+    service = TestBed.inject(UserService);
+    api = TestBed.inject(UserApi) as unknown as UserApiStub;
+    store = TestBed.inject(UserStore) as unknown as UserStoreStub;
+    competitionStore = TestBed.inject(CompetitionStore) as unknown as CompetitionStoreStub;
+  });
+
+  it('should return cached user state when available', (done) => {
+    store.set(baseState);
+
+    service.getState().subscribe(state => {
+      expect(state).toEqual(baseState);
+      expect(api.getUserState).not.toHaveBeenCalled();
+      done();
+    });
+  });
+
+  it('should fetch user state from API when forced', (done) => {
+    const freshState = { ...baseState, nickname: 'Updated' };
+    api.getUserState.and.returnValue(of(freshState));
+
+    service.getState(true).subscribe(state => {
+      expect(api.getUserState).toHaveBeenCalled();
+      expect(state).toEqual(freshState);
+      expect(store.setSpy).toHaveBeenCalledWith(freshState);
+      expect(competitionStore.upsertOne).toHaveBeenCalled();
+      expect(competitionStore.setActive).toHaveBeenCalledWith(freshState.active_competition.id ?? freshState.active_competition.competition_id);
+      done();
+    });
+  });
+
+  it('should update remote state and patch optimistically', (done) => {
+    store.set(baseState);
+    const serverState = { ...baseState, nickname: 'Remote' };
+    api.updateUserState.and.returnValue(of(serverState));
+
+    service.updateRemote({ nickname: 'Local' }).subscribe(state => {
+      expect(api.updateUserState).toHaveBeenCalledWith({ nickname: 'Local' });
+      expect(store.patchSpy).toHaveBeenCalledWith({ nickname: 'Local' });
+      expect(store.setSpy).toHaveBeenCalledWith(serverState);
+      expect(state).toEqual(serverState);
+      done();
+    });
+  });
+
+  it('should set active competition id locally and on store', () => {
+    store.set(baseState);
+
+    service.setActiveCompetitionId(5);
+    expect(store.patchSpy).toHaveBeenCalledWith({ active_competition_id: 5 });
+    expect(competitionStore.setActive).toHaveBeenCalledWith(5);
+
+    store.patchSpy.calls.reset();
+    service.setActiveCompetitionId(null);
+    expect(store.patchSpy).toHaveBeenCalledWith({ active_competition_id: null });
+    expect(competitionStore.setActive).toHaveBeenCalledWith(null);
+  });
+
+  it('should clear store on clear()', () => {
+    service.clear();
+    expect(store.clearSpy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add comprehensive Jasmine specs for AddMatchModal, Matches, and Landing components including edge-case behaviours
- introduce targeted service tests for translation, loader, auth, competitions, data, ranking, dropdown, modal, players, and user logic to validate caching, error handling, and state updates

## Testing
- npm run test -- --watch=false --browsers=ChromeHeadless *(fails: ChromeHeadless binary is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d87f4011188322a249908168eab2e5