### PR TITLE
Add confirmation modal for competition deletions

### DIFF
--- a/public/lang.json
+++ b/public/lang.json
@@ -859,9 +859,13 @@
         "it": "Sei sicuro?",
         "en": "Are you sure?"
     },
-    "are-you-sure-deleting": {
+    "are-you-sure-delete-player": {
         "it": "Sei sicuro di voler eliminare il giocatore?",
         "en": "Are you sure you want to delete the player?"
+    },
+    "are-you-sure-delete-competition": {
+        "it": "Sei sicuro di voler eliminare la competizione?",
+        "en": "Are you sure you want to delete the competition?"
     },
     "delete_player": {
         "it": "Elimina giocatore",

--- a/src/app/common/are-you-sure/are-you-sure.component.ts
+++ b/src/app/common/are-you-sure/are-you-sure.component.ts
@@ -16,5 +16,5 @@ export class AreYouSureComponent extends ModalComponent {
   }
   @Output() confirmed = new EventEmitter<boolean>();
   @Output() cancelled = new EventEmitter<boolean>();
-  @Input() body: string = 'Are you sure you want to delete the player?';
+  @Input() body: string = 'Are you sure you want to proceed?';
 }

--- a/src/app/components/competitions/competition-detail/competition-detail.component.html
+++ b/src/app/components/competitions/competition-detail/competition-detail.component.html
@@ -42,7 +42,7 @@
         <img *ngIf="p.image_url" class="avatar" [src]="p.image_url" />
         <img *ngIf="!p.image_url" class="avatar" [src]="'default-player.jpg'" />
         <span class="player-name">{{ p.nickname }}</span>
-        <button class="delete" (click)="openAreYouSureModal(p.id)">
+        <button class="delete" (click)="requestPlayerDeletion(p.id)">
           <i class="fa-solid fa-trash-o"></i>
         </button>
       </button>

--- a/src/app/components/competitions/competition-detail/competition-detail.component.ts
+++ b/src/app/components/competitions/competition-detail/competition-detail.component.ts
@@ -23,8 +23,6 @@ export class CompetitionDetailComponent implements OnDestroy {
 
   @Input() competition: ICompetition | null = null;
 
-  playerIdToDelete: number = -1;
-
   @ViewChild('competitionDetail', { static: true }) competitionDetailRef!: ElementRef<HTMLElement>;
 
   ngOnChanges() {
@@ -32,6 +30,8 @@ export class CompetitionDetailComponent implements OnDestroy {
   }
   @Output() actionSelected = new EventEmitter<{ action: string, competition: ICompetition | null }>();
   @Output() changeCompetitionSelected = new EventEmitter<ICompetition>();
+  @Output() deletePlayerRequested = new EventEmitter<number>();
+  @Output() deleteCompetitionRequested = new EventEmitter<ICompetition | null>();
   copied: boolean = false;
   private competitionService = inject(CompetitionService);
   public dropdownService = inject(DropdownService);
@@ -76,9 +76,7 @@ export class CompetitionDetailComponent implements OnDestroy {
         window.location.reload();
         break;
       case 'delete':
-        this.competitionService.remove(this.competition.id).subscribe(() => {
-          this.competitionService.getCompetitions(true);
-        });
+        this.deleteCompetitionRequested.emit(this.competition);
         break;
       case 'details':
         this.changeCompetitionSelected.emit(this.competition);
@@ -129,16 +127,9 @@ export class CompetitionDetailComponent implements OnDestroy {
       this.loader.showToast(this.translateService.translate('player_removed'), MSG_TYPE.SUCCESS);
     });
   }
-  openAreYouSureModal(playerId: number) {
-    this.playerIdToDelete = playerId;
-    this.modalService.openModal(this.modalService.MODALS['ARE_YOU_SURE']);
-  }
-  onDeleteConfirmed() {
-    this.modalService.closeModal();
-    this.deletePlayer(this.playerIdToDelete);
-  }
-  onDeleteCancelled() {
-    this.modalService.closeModal();
+
+  requestPlayerDeletion(playerId: number) {
+    this.deletePlayerRequested.emit(playerId);
   }
 
   private subscriptions = new Subscription();

--- a/src/app/components/competitions/competitions/competitions.component.html
+++ b/src/app/components/competitions/competitions/competitions.component.html
@@ -54,7 +54,9 @@
             <!-- Dettaglio competizione attiva -->
             <ng-container *ngIf="activeCompetition$ | async as activeCompetition">
                 <section *ngIf="activeCompetition">
-                    <app-competition-detail [competition]="activeCompetition" (changeCompetitionSelected)="updateCompetitionDetail($event)"></app-competition-detail>
+                    <app-competition-detail [competition]="activeCompetition" (changeCompetitionSelected)="updateCompetitionDetail($event)"
+                        (deletePlayerRequested)="onDeletePlayerRequested($event)"
+                        (deleteCompetitionRequested)="onDeleteCompetitionRequested($event)"></app-competition-detail>
                 </section>
             </ng-container>
 
@@ -171,7 +173,7 @@
 
     <app-modal [label]="'are_you_sure'" *ngIf="modalService.isActiveModal(modalService.MODALS['ARE_YOU_SURE'])"
         [modalName]="modalService.MODALS['ARE_YOU_SURE']" (closeModalEvent)="modalService.closeModal()">
-        <are-you-sure [body]="'are-you-sure-deleting' | translate" (confirmed)="onDeleteConfirmed()"
+        <are-you-sure [body]="confirmationBodyKey | translate" (confirmed)="onDeleteConfirmed()"
             (cancelled)="onDeleteCancelled()"></are-you-sure>
     </app-modal>
 </ng-container>


### PR DESCRIPTION
## Summary
- route competition deletion flows through the shared are-you-sure modal in the competition detail and list views
- add reusable delete events so the parent component controls confirmation callbacks
- extend translations for competition/player delete prompts and generalize the are-you-sure component default message

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd281c0ef48322902448eb3b4df23d