### PR TITLE
Simplify dropdown toggle logic

### DIFF
--- a/src/services/dropdown.service.ts
+++ b/src/services/dropdown.service.ts
@@ -17,31 +17,24 @@ interface DropdownState {
 export class DropdownService {
   private stateSubject = new BehaviorSubject<DropdownState | null>(null);
   readonly state$ = this.stateSubject.asObservable();
-  static isOpen = false;
   private actionSubject = new Subject<string>();
   readonly action$ = this.actionSubject.asObservable();
 
   open(actions: DropdownAction[], anchor: HTMLElement) {
-    const currentState = this.stateSubject.getValue();
-    if (DropdownService.isOpen) {
-      // Se l'anchor è diverso, apri semplicemente il nuovo menu senza chiudere prima
-      if (currentState && currentState.anchor !== anchor) {
-        this.stateSubject.next({ actions, anchor });
-        return;
-      }
-      this.close();
-      return;
-    }
     if (!anchor) {
       return;
     }
+    const currentState = this.stateSubject.getValue();
+    if (currentState && currentState.anchor === anchor) {
+      this.close();
+      return;
+    }
+
     this.stateSubject.next({ actions, anchor });
-    DropdownService.isOpen = true;
   }
 
   close() {
     this.stateSubject.next(null);
-    DropdownService.isOpen = false;
   }
 
   emit(value: string) {


### PR DESCRIPTION
## Summary
- simplify the dropdown service to rely on the current state instead of a static flag
- ensure clicking the same anchor toggles the menu while other anchors open correctly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dee2db4f488322b1c47607c967ccfc