### PR TITLE
Prevent dropdown auto focus from closing the menu

### DIFF
--- a/src/app/common/menu-dropdown/menu-dropdown.component.ts
+++ b/src/app/common/menu-dropdown/menu-dropdown.component.ts
@@ -109,7 +109,15 @@ export class MenuDropdownComponent implements OnDestroy {
 
   private focusFirstItem() {
     const first = this.menuItems?.first?.nativeElement;
-    first?.focus();
+    if (!first) {
+      return;
+    }
+
+    if (typeof first.focus === 'function') {
+      first.focus({ preventScroll: true });
+    } else {
+      first.focus();
+    }
   }
 
   private moveFocus(direction: 1 | -1) {


### PR DESCRIPTION
## Summary
- avoid programmatic focus from scrolling the page when opening the dropdown, preventing the menu from closing immediately

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68e5822e11208322b11f62b56db87664