### PR TITLE
Add basic unit tests for shared UI helpers

### DIFF
--- a/src/app/common/modal/modal.component.spec.ts
+++ b/src/app/common/modal/modal.component.spec.ts
@@ -1,0 +1,63 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { EventEmitter } from '@angular/core';
+import { ModalComponent } from './modal.component';
+import { ModalService } from '../../../services/modal.service';
+
+class ModalServiceStub {
+  closeModal = jasmine.createSpy('closeModal');
+}
+
+describe('ModalComponent', () => {
+  let component: ModalComponent;
+  let fixture: ComponentFixture<ModalComponent>;
+  let modalService: ModalServiceStub;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ModalComponent],
+      providers: [
+        { provide: ModalService, useClass: ModalServiceStub }
+      ]
+    }).overrideComponent(ModalComponent, {
+      set: { template: '' }
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ModalComponent);
+    component = fixture.componentInstance;
+    modalService = TestBed.inject(ModalService) as unknown as ModalServiceStub;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should toggle fullscreen state', () => {
+    component.fullscreen = false;
+
+    component.toggleFullscreen();
+
+    expect(component.fullscreen).toBeTrue();
+  });
+
+  it('should close modal and emit event', () => {
+    const spy = jasmine.createSpy('close');
+    component.closeModalEvent = new EventEmitter<void>();
+    component.closeModalEvent.subscribe(spy);
+
+    component.closeModal();
+
+    expect(modalService.closeModal).toHaveBeenCalled();
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('should replace image source on error', () => {
+    const image = document.createElement('img');
+    const event = new Event('error');
+    Object.defineProperty(event, 'target', { value: image });
+
+    component.onImageError(event);
+
+    expect(image.src).toContain('/default-player.jpg');
+  });
+});

--- a/src/app/common/step-indicator/step-indicator.component.spec.ts
+++ b/src/app/common/step-indicator/step-indicator.component.spec.ts
@@ -1,0 +1,51 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { StepIndicatorComponent } from './step-indicator.component';
+
+describe('StepIndicatorComponent', () => {
+  let component: StepIndicatorComponent;
+  let fixture: ComponentFixture<StepIndicatorComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [StepIndicatorComponent]
+    }).overrideComponent(StepIndicatorComponent, {
+      set: { template: '' }
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(StepIndicatorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should emit stepClick when clickable and step is allowed', () => {
+    const spy = jasmine.createSpy('stepClick');
+    component.clickable = true;
+    component.activeStep = 3;
+    component.stepClick.subscribe(spy);
+
+    component.onStepClick(2);
+
+    expect(spy).toHaveBeenCalledOnceWith(2);
+  });
+
+  it('should not emit stepClick when step is not allowed', () => {
+    const spy = jasmine.createSpy('stepClick');
+    component.clickable = true;
+    component.activeStep = 1;
+    component.stepClick.subscribe(spy);
+
+    component.onStepClick(2);
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('should create array for total steps', () => {
+    component.totalSteps = 4;
+
+    expect(component.stepsArray()).toEqual([1, 2, 3, 4]);
+  });
+});

--- a/src/app/utils/translate.pipe.spec.ts
+++ b/src/app/utils/translate.pipe.spec.ts
@@ -1,0 +1,20 @@
+import { TranslatePipe } from './translate.pipe';
+import { TranslationService } from '../../services/translation.service';
+
+describe('TranslatePipe', () => {
+  let pipe: TranslatePipe;
+  let translationService: jasmine.SpyObj<TranslationService>;
+
+  beforeEach(() => {
+    translationService = jasmine.createSpyObj<TranslationService>('TranslationService', ['translate']);
+    translationService.translate.and.callFake((value: string) => `${value}-translated`);
+    pipe = new TranslatePipe(translationService);
+  });
+
+  it('should call translation service when transforming value', () => {
+    const result = pipe.transform('hello');
+
+    expect(translationService.translate).toHaveBeenCalledWith('hello');
+    expect(result).toBe('hello-translated');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for the step indicator component to validate step generation and click handling
- cover modal component helpers for closing behavior, fullscreen toggle, and image fallback logic
- ensure the translate pipe delegates work to the translation service

## Testing
- npm test -- --watch=false --browsers=ChromeHeadless *(fails: ChromeHeadless binary missing in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e59c1cc61083229b0a19cad2a1168b